### PR TITLE
Contrast 18474 update json serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This library is also provided as a nuget package: https://www.nuget.org/packages
 
 Please see http://www.contrastsecurity.com for more information about how Contrast can help secure your applications.
 
+## Dependencies
+* Newtonsoft.Json
+
 
 ## Contrast TeamServer API Credentials
 To access the TeamServer API, you'll first need access to TeamServer - either SAAS (https://app.contrastsecurity.com/Contrast/login.html) or an on-premises installation of TeamServer.

--- a/contrast-rest-dotnet/Http/ServerFilter.cs
+++ b/contrast-rest-dotnet/Http/ServerFilter.cs
@@ -91,10 +91,10 @@ namespace contrast_rest_dotnet.Http
                 filters.Add("expand=" + String.Join(",", Expand));
 
             if (StartDate != null)
-                filters.Add("startDate=" + DateTimeConverter.ConvertToUnixTime(StartDate));
+                filters.Add("startDate=" + DateTimeConverter.ConvertToEpochTime(StartDate.Value));
 
             if (EndDate != null)
-                filters.Add("endDate=" + DateTimeConverter.ConvertToUnixTime(EndDate));
+                filters.Add("endDate=" + DateTimeConverter.ConvertToEpochTime(EndDate.Value));
 
             if (Severities != null && Severities.Count > 0)
                 filters.Add("severities=" + String.Join(",", Severities));

--- a/contrast-rest-dotnet/Http/TraceFilter.cs
+++ b/contrast-rest-dotnet/Http/TraceFilter.cs
@@ -102,10 +102,10 @@ namespace contrast_rest_dotnet.Http
                 filters.Add("expand=" + String.Join(",", Expand));
 
             if (StartDate != null)
-                filters.Add("startDate=" + DateTimeConverter.ConvertToUnixTime(StartDate));
+                filters.Add("startDate=" + DateTimeConverter.ConvertToEpochTime(StartDate.Value));
 
             if(EndDate != null)
-                filters.Add("endDate=" + DateTimeConverter.ConvertToUnixTime(EndDate));
+                filters.Add("endDate=" + DateTimeConverter.ConvertToEpochTime(EndDate.Value));
 
             if (FilterTags != null && FilterTags.Count > 0)
                 filters.Add("filterTags=" + String.Join(",", FilterTags));

--- a/contrast-rest-dotnet/Model/Card.cs
+++ b/contrast-rest-dotnet/Model/Card.cs
@@ -28,48 +28,47 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class Card
     {
         /// <summary>
         /// Returns the body snippet as a Dictionary
         /// </summary>
-        [DataMember(Name = "body")]
+        [JsonProperty(PropertyName = "body")]
         public object Body { get; set; }
 
         /// <summary>
         /// Returns the header snippet as a Dictionary
         /// </summary>
-        [DataMember(Name = "header")]
+        [JsonProperty(PropertyName = "header")]
         public object Header { get; set; }
 
         /// <summary>
         /// Hidden status of Card.
         /// </summary>
-        [DataMember(Name = "is_hidden")]
+        [JsonProperty(PropertyName = "is_hidden")]
         public bool IsHidden { get; set; }
 
         /// <summary>
         /// Severity level of card.
         /// </summary>
-        [DataMember(Name = "severity")]
+        [JsonProperty(PropertyName = "severity")]
         public string Severity { get; set; }
 
         /// <summary>
         /// Card title.
         /// </summary>
-        [DataMember(Name = "title")]
+        [JsonProperty(PropertyName = "title")]
         public string Title { get; set; }
 
         /// <summary>
         /// Trace id the card belongs to.
         /// </summary>
-        [DataMember(Name = "traceId")]
+        [JsonProperty(PropertyName = "traceId")]
         public string TraceId { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/CodeView.cs
+++ b/contrast-rest-dotnet/Model/CodeView.cs
@@ -28,55 +28,55 @@
  */
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class CodeView
     {
         /// <summary>
         /// List of code lines.
         /// </summary>
-        [DataMember(Name = "lines")]
+        [JsonProperty(PropertyName = "lines")]
         public List<CodeLine> Lines { get; set; }
 
         /// <summary>
         /// If the code view is nested.
         /// </summary>
-        [DataMember(Name = "nested")]
+        [JsonProperty(PropertyName = "nested")]
         public bool Nested { get; set; }
     }
     
-    [DataContract]
+    [JsonObject]
     public class CodeLine
     {
         /// <summary>
         /// Formatted fragments of code.
         /// </summary>
-        [DataMember(Name = "fragments")]
+        [JsonProperty(PropertyName = "fragments")]
         public List<LineFragment> Fragments { get; set; }
 
         /// <summary>
         /// Full line of code.
         /// </summary>
-        [DataMember(Name = "text")]
+        [JsonProperty(PropertyName = "text")]
         public string Text { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class LineFragment
     {
         /// <summary>
         /// Type of fragment.
         /// </summary>
-        [DataMember(Name = "type")]
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Fragment content.
         /// </summary>
-        [DataMember(Name = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string value { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/ContrastApplication.cs
+++ b/contrast-rest-dotnet/Model/ContrastApplication.cs
@@ -90,12 +90,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "code_shorthand")]
         public string CodeShorthand { get; set; }
 
-        [JsonProperty(PropertyName = "created")]
-        public long? CreatedRawValue { get; set; }
-
         /// <summary>
         /// Time it was created.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "created")]
         public DateTime? Created { get; set; }
 
         /// <summary>
@@ -128,20 +127,18 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "language")]
         public string Language { get; set; }
 
-        [JsonProperty(PropertyName = "last_reset")]
-        private long? LastResetRawValue { get; set; }
-
         /// <summary>
         /// Time last reset.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "last_reset")]
         public DateTime? LastReset { get; set; }
-
-        [JsonProperty(PropertyName = "last_seen")]
-        private long LastSeenRawValue { get; set; }
 
         /// <summary>
         /// Return the time the application was last monitored by Contrast.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "last_seen")]
         public DateTime? LastSeen { get; set; }
 
         /// <summary>
@@ -264,14 +261,6 @@ namespace contrast_rest_dotnet.Model
         /// </summary>
         [JsonProperty(PropertyName = "trace_breakdown")]
         public TraceBreakdown TraceBreakdown { get; set; }
-
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            Created = DateTimeConverter.ConvertToDateTime(CreatedRawValue);
-            LastReset = DateTimeConverter.ConvertToDateTime(LastResetRawValue);
-            LastSeen = DateTimeConverter.ConvertToDateTime(LastSeenRawValue);
-        }
     }
 
     [JsonObject]

--- a/contrast-rest-dotnet/Model/ContrastApplication.cs
+++ b/contrast-rest-dotnet/Model/ContrastApplication.cs
@@ -30,6 +30,7 @@
 using contrast_rest_dotnet.Serialization;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using System.Runtime.Serialization;
 
 namespace contrast_rest_dotnet.Model
@@ -37,59 +38,59 @@ namespace contrast_rest_dotnet.Model
     /// <summary>
     /// An application that is being monitored by Contrast.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class ContrastApplication
     {
         /// <summary>
         /// Gets the ID of this application, which is a long, alphanumeric token.
         /// </summary>
-        [DataMember(Name="app_id")]
+        [JsonProperty(PropertyName="app_id")]
         public string AppID { get; set; }
 
         /// <summary>
         /// If the application is archived
         /// </summary>
-        [DataMember(Name = "archived")]
+        [JsonProperty(PropertyName = "archived")]
         public bool Archived { get; set; }
 
         /// <summary>
         /// If the application has assessment enabled.
         /// </summary>
-        [DataMember(Name = "assess")]
+        [JsonProperty(PropertyName = "assess")]
         public bool Assess { get; set; }
 
         /// <summary>
         /// If application has assessment pending for at least one of this
         /// application's server.
         /// </summary>
-        [DataMember(Name = "assessPending")]
+        [JsonProperty(PropertyName = "assessPending")]
         public bool AssessPending { get; set; }
 
         /// <summary>
         /// Attack status label.
         /// </summary>
-        [DataMember(Name = "attack_label")]
+        [JsonProperty(PropertyName = "attack_label")]
         public string AttackLabel { get; set; }
 
         /// <summary>
         /// Attack status. Allowed values: PROBED, EXPLOITED.
         /// </summary>
-        [DataMember(Name = "attack_status")]
+        [JsonProperty(PropertyName = "attack_status")]
         public string AttackStatus { get; set; }
 
         /// <summary>
         /// Custom classes LoC
         /// </summary>
-        [DataMember(Name = "code")]
+        [JsonProperty(PropertyName = "code")]
         public long? Code { get; set; }
 
         /// <summary>
         /// Custom classes LoC shorthand
         /// </summary>
-        [DataMember(Name = "code_shorthand")]
+        [JsonProperty(PropertyName = "code_shorthand")]
         public string CodeShorthand { get; set; }
 
-        [DataMember(Name = "created")]
+        [JsonProperty(PropertyName = "created")]
         public long? CreatedRawValue { get; set; }
 
         /// <summary>
@@ -100,34 +101,34 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// If Defense is enabled.
         /// </summary>
-        [DataMember(Name = "defend")]
+        [JsonProperty(PropertyName = "defend")]
         public bool Defend { get; set; }
 
         /// <summary>
         /// If Defense is pending for any of this application's servers.
         /// </summary>
-        [DataMember(Name = "defendPending")]
+        [JsonProperty(PropertyName = "defendPending")]
         public bool DefendPending { get; set; }
 
         /// <summary>
         /// Gets the group name.
         /// </summary>
-        [DataMember(Name = "group_name")]
+        [JsonProperty(PropertyName = "group_name")]
         public string GroupName { get; set; }
 
         /// <summary>
         /// Application importance.
         /// </summary>
-        [DataMember(Name = "importance")]
+        [JsonProperty(PropertyName = "importance")]
         public int? Importance { get; set; }
 
         /// <summary>
         /// Gets the language of the application, e.g., Java.
         /// </summary>
-        [DataMember(Name = "language")]
+        [JsonProperty(PropertyName = "language")]
         public string Language { get; set; }
 
-        [DataMember(Name = "last_reset")]
+        [JsonProperty(PropertyName = "last_reset")]
         private long? LastResetRawValue { get; set; }
 
         /// <summary>
@@ -135,7 +136,7 @@ namespace contrast_rest_dotnet.Model
         /// </summary>
         public DateTime? LastReset { get; set; }
 
-        [DataMember(Name = "last_seen")]
+        [JsonProperty(PropertyName = "last_seen")]
         private long LastSeenRawValue { get; set; }
 
         /// <summary>
@@ -146,122 +147,122 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Gets the license level of the applied; one of Enterprise, Business, Pro, Trial 
         /// </summary>
-        [DataMember(Name = "license")]
+        [JsonProperty(PropertyName = "license")]
         public ApplicationLicense License { get; set; }
 
         /// <summary>
         /// Gets a list of Contrast REST URLs for this application.
         /// </summary>
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
 
         /// <summary>
         /// If this application is master.
         /// </summary>
-        [DataMember(Name = "master")]
+        [JsonProperty(PropertyName = "master")]
         public bool Master { get; set; }
 
         /// <summary>
         /// Application child modules
         /// </summary>
-        [DataMember(Name = "modules")]
+        [JsonProperty(PropertyName = "modules")]
         public List<ApplicationModule> Modules { get; set; }
 
         /// <summary>
         /// Gets the human-readable name of the web application. Note that this method will
         /// return the site name for apps that run at the root of the app.
         /// </summary>
-        [DataMember(Name="name")]
+        [JsonProperty(PropertyName="name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Application notes.
         /// </summary>
-        [DataMember(Name = "notes")]
+        [JsonProperty(PropertyName = "notes")]
         public string Notes { get; set; }
 
         /// <summary>
         /// Override url for this application.
         /// </summary>
-        [DataMember(Name = "override_url")]
+        [JsonProperty(PropertyName = "override_url")]
         public string OverrideUrl { get; set; }
 
         /// <summary>
         /// Parent application ID.
         /// </summary>
-        [DataMember(Name = "parentApplication")]
+        [JsonProperty(PropertyName = "parentApplication")]
         public string ParentApplicationId { get; set; }
 
         /// <summary>
         /// Gets the path of the web application, e.g., /AcmeApp
         /// </summary>
-        [DataMember(Name = "path")]
+        [JsonProperty(PropertyName = "path")]
         public string Path { get; set; }
 
         /// <summary>
         /// List of allowed roles.
         /// </summary>
-        [DataMember(Name = "roles")]
+        [JsonProperty(PropertyName = "roles")]
         public List<string> Roles { get; set; }
 
         /// <summary>
         /// List of application scores.
         /// </summary>
-        [DataMember(Name = "scores")]
+        [JsonProperty(PropertyName = "scores")]
         public List<Score> Scores { get; set; }
 
         /// <summary>
         /// If this application has servers without protection enabled.
         /// </summary>
-        [DataMember(Name = "serversWithoutDefend")]
+        [JsonProperty(PropertyName = "serversWithoutDefend")]
         public bool ServersWithoutDefend { get; set; }
 
         /// <summary>
         /// Application's short name.
         /// </summary>
-        [DataMember(Name = "short_name")]
+        [JsonProperty(PropertyName = "short_name")]
         public string ShortName { get; set; }
 
         /// <summary>
         /// Total LoC
         /// </summary>
-        [DataMember(Name = "size")]
+        [JsonProperty(PropertyName = "size")]
         public long? Size { get; set; }
 
         /// <summary>
         /// Total LoC shorthand.
         /// </summary>
-        [DataMember(Name = "size_shorthand")]
+        [JsonProperty(PropertyName = "size_shorthand")]
         public string SizeShorthand { get; set; }
 
         /// <summary>
         /// Application status
         /// </summary>
-        [DataMember(Name = "status")]
+        [JsonProperty(PropertyName = "status")]
         public string Stauts { get; set; }
 
         /// <summary>
         /// List of tags
         /// </summary>
-        [DataMember(Name = "tags")]
+        [JsonProperty(PropertyName = "tags")]
         public List<string> Tags { get; set; }
 
         /// <summary>
         /// Gets a list of technologies the app is using, e.g., WebForms, Spring, Applet, JSF, Flash, etc.
         /// </summary>
-        [DataMember(Name = "techs")]
+        [JsonProperty(PropertyName = "techs")]
         public List<string> Technologies { get; set; }
 
         /// <summary>
         /// Number of app modules.
         /// </summary>
-        [DataMember(Name = "total_modules")]
+        [JsonProperty(PropertyName = "total_modules")]
         public long? TotalModules { get; set; }
 
         /// <summary>
         /// Application vulnerability breakdown.
         /// </summary>
-        [DataMember(Name = "trace_breakdown")]
+        [JsonProperty(PropertyName = "trace_breakdown")]
         public TraceBreakdown TraceBreakdown { get; set; }
 
         [OnDeserialized]
@@ -273,57 +274,57 @@ namespace contrast_rest_dotnet.Model
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class ApplicationLicense
     {
         /// <summary>
         /// License end time
         /// </summary>
-        [DataMember(Name = "end")]
+        [JsonProperty(PropertyName = "end")]
         public long End { get; set; }
 
         /// <summary>
         /// Service level
         /// </summary>
-        [DataMember(Name = "level")]
+        [JsonProperty(PropertyName = "level")]
         public string Level { get; set; }
 
         /// <summary>
         /// If license is near expiration time.
         /// </summary>
-        [DataMember(Name = "near_expiration")]
+        [JsonProperty(PropertyName = "near_expiration")]
         public bool NearExpiration { get; set; }
 
         /// <summary>
         /// License start time.
         /// </summary>
-        [DataMember(Name = "start")]
+        [JsonProperty(PropertyName = "start")]
         public long Start { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class ApplicationResponse
     {
-        [DataMember(Name = "application")]
+        [JsonProperty(PropertyName = "application")]
         public ContrastApplication Application { get; set; }
 
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class ApplicationsResponse
     {
-        [DataMember(Name = "applications")]
+        [JsonProperty(PropertyName = "applications")]
         public List<ContrastApplication> Applications { get; set; }
 
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Library.cs
+++ b/contrast-rest-dotnet/Model/Library.cs
@@ -29,42 +29,42 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
     /// <summary>
     /// An application library.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Library
     {
         /// <summary>
         /// Gets the ID of this library.
         /// </summary>
         [Obsolete("Not supported.")]
-        [DataMember(Name = "library_id")]
+        [JsonProperty(PropertyName = "library_id")]
         public string LibraryId { get; set; }
 
         /// <summary>
         /// Gets the filename of this library.
         /// </summary>
-        [DataMember(Name = "file_name")]
+        [JsonProperty(PropertyName = "file_name")]
         public string FileName { get; set; }
 
-        [DataMember(Name = "app_language")]
+        [JsonProperty(PropertyName = "app_language")]
         public string AppLanguage { get; set; }
 
         /// <summary>
         /// If this library is custom.
         /// </summary>
-        [DataMember(Name = "custom")]
+        [JsonProperty(PropertyName = "custom")]
         public bool Custom { get; set; }
 
         /// <summary>
         /// Gets the number of classes in this library.
         /// </summary>
-        [DataMember(Name = "class_count")]
+        [JsonProperty(PropertyName = "class_count")]
         public int ClassCount { get; set; }
 
         /// <summary>
@@ -74,66 +74,66 @@ namespace contrast_rest_dotnet.Model
 	    /// the total number of distinct classes used across all instances of the
 	    /// running application.
         /// </summary>
-        [DataMember(Name = "class_used")]
+        [JsonProperty(PropertyName = "class_used")]
         public int UsedClassCount { get; set; }
 
         /// <summary>
         /// Gets the version of this library according to the library authority
 	    /// like Maven Central or NuGet.
         /// </summary>
-        [DataMember(Name = "file_version")]
+        [JsonProperty(PropertyName = "file_version")]
         public string Version { get; set; }
 
-        [DataMember(Name = "grade")]
+        [JsonProperty(PropertyName = "grade")]
         public String Grade { get; set; }
 
         /// <summary>
         /// Library hash.
         /// </summary>
-        [DataMember(Name = "hash")]
+        [JsonProperty(PropertyName = "hash")]
         public string Hash { get; set; }
 
         /// <summary>
         /// Gets a list of Contrast REST endpoint URLs for this library.
         /// </summary>
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
 
-        [DataMember(Name = "latest_release_date")]
+        [JsonProperty(PropertyName = "latest_release_date")]
         public long? LatestReleaseDate { get; set; }
 
-        [DataMember(Name = "months_outdated")]
+        [JsonProperty(PropertyName = "months_outdated")]
         public long? MonthsOutdated { get; set; }
 
-        [DataMember(Name = "release_date")]
+        [JsonProperty(PropertyName = "release_date")]
         public long? ReleaseDate { get; set; }
 
-        [DataMember(Name = "total_vulnerabilities")]
+        [JsonProperty(PropertyName = "total_vulnerabilities")]
         public long TotalVulnerabilities { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class LibraryResponse
     {
         /// <summary>
         /// Average months
         /// </summary>
-        [DataMember(Name = "averageMonths")]
+        [JsonProperty(PropertyName = "averageMonths")]
         public int? AverageMonths { get; set; }
 
         /// <summary>
         /// Average score.
         /// </summary>
-        [DataMember(Name = "averageScore")]
+        [JsonProperty(PropertyName = "averageScore")]
         public int? AverageScore { get; set; }
 
         /// <summary>
         /// Average score letter.
         /// </summary>
-        [DataMember(Name = "averageScoreLetter")]
+        [JsonProperty(PropertyName = "averageScoreLetter")]
         public string AverageScoreLetter { get; set; }
 
-        [DataMember(Name = "libraries")]
+        [JsonProperty(PropertyName = "libraries")]
         public List<Library> Libraries { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Link.cs
+++ b/contrast-rest-dotnet/Model/Link.cs
@@ -27,32 +27,32 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
     /// <summary>
     /// A link containing a URL to a Contrast REST endpoint.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Link
     {
         /// <summary>
         /// Gets the name of the endpoint.
         /// </summary>
-        [DataMember(Name="rel")]
+        [JsonProperty(PropertyName="rel")]
         public string Rel { get; set; }
 
         /// <summary>
         /// Gets the REST endpoint URL.
         /// </summary>
-        [DataMember(Name = "href")]
+        [JsonProperty(PropertyName = "href")]
         public string Href { get; set; }
 
         /// <summary>
         /// Get the request method.
         /// </summary>
-        [DataMember(Name = "method")]
+        [JsonProperty(PropertyName = "method")]
         public string Method { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/NgApplication.cs
+++ b/contrast-rest-dotnet/Model/NgApplication.cs
@@ -28,53 +28,53 @@
  */
 
 using System;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class ApplicationModule
     {
         /// <summary>
         /// Application id.
         /// </summary>
-        [DataMember(Name = "app_id")]
+        [JsonProperty(PropertyName = "app_id")]
         public string AppId { get; set; }
 
         /// <summary>
         /// If the application is archived.
         /// </summary>
-        [DataMember(Name = "archived")]
+        [JsonProperty(PropertyName = "archived")]
         public bool Archived { get; set; }
 
         /// <summary>
         /// Service level. Allowed values: Unlicensed, Enterprise.
         /// </summary>
-        [DataMember(Name = "level")]
+        [JsonProperty(PropertyName = "level")]
         public string Level { get; set; }
 
         /// <summary>
         /// Application name.
         /// </summary>
-        [DataMember(Name = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Application path.
         /// </summary>
-        [DataMember(Name = "path")]
+        [JsonProperty(PropertyName = "path")]
         public string Path { get; set; }
 
         /// <summary>
         /// Total LoC shorthand.
         /// </summary>
-        [DataMember(Name = "size_shorthand")]
+        [JsonProperty(PropertyName = "size_shorthand")]
         public string SizeShorthand { get; set; }
 
         /// <summary>
         /// Short name.
         /// </summary>
-        [DataMember(Name = "short_name")]
+        [JsonProperty(PropertyName = "short_name")]
         public string ShortName { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Parameter.cs
+++ b/contrast-rest-dotnet/Model/Parameter.cs
@@ -27,26 +27,26 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
     /// <summary>
     /// The name=value pair for HTTP request parameters.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Parameter
     {
         /// <summary>
         /// Gets the name of the parameter.
         /// </summary>
-        [DataMember(Name = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets the value of the parameter.
         /// </summary>
-        [DataMember(Name = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Profile.cs
+++ b/contrast-rest-dotnet/Model/Profile.cs
@@ -29,65 +29,62 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
     /// <summary>
     /// A profile for agent downloads containing specifics for TeamServer URL, proxy settings, etc.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Profile
     {
         /// <summary>
         /// Gets the name of the profile.
         /// </summary>
-        [DataMember(Name = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets the sampling baseline.
         /// </summary>
-        [DataMember(Name = "samplingBaseline")]
+        [JsonProperty(PropertyName = "samplingBaseline")]
         public int SamplingBaseline { get; set; }
 
         /// <summary>
         /// Gets the sampling window.
         /// </summary>
-        [DataMember(Name = "samplingWindow")]
+        [JsonProperty(PropertyName = "samplingWindow")]
         public int SamplingWindow { get; set; }
 
         /// <summary>
         /// Gets the sampling frequency.
         /// </summary>
-        [DataMember(Name = "samplingFrequency")]
+        [JsonProperty(PropertyName = "samplingFrequency")]
         public int SamplingFrequency { get; set; }
 
         /// <summary>
         /// Gets the stack trace capture mode.
         /// </summary>
-        [DataMember(Name = "stacktraceCaptureMode")]
+        [JsonProperty(PropertyName = "stacktraceCaptureMode")]
         public string StackTraceCaptureMode { get; set; }
 
         /// <summary>
         /// Gets whether this agent will use a proxy.
         /// </summary>
-        [DataMember(Name = "useProxy")]
+        [JsonProperty(PropertyName = "useProxy")]
         public bool UseProxy { get; set; }
 
         /// <summary>
         /// Gets the TeamServerUrl.
         /// </summary>
-        [DataMember(Name = "overrideTeamServerUrl")]
+        [JsonProperty(PropertyName = "overrideTeamServerUrl")]
         public bool OverrideTeamServerUrl { get; set; }
 
         /// <summary>
         /// Gets a list of Contrast REST endpoint URLs for this profile.
         /// </summary>
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Request.cs
+++ b/contrast-rest-dotnet/Model/Request.cs
@@ -28,81 +28,81 @@
  */
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
     /// <summary>
     /// An HTTP request associated with a trace.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Request
     {
         /// <summary>
         /// Gets the protocol of the request.
         /// </summary>
-        [DataMember(Name = "protocol")]
+        [JsonProperty(PropertyName = "protocol")]
         public string Protocol { get; set; }
 
         /// <summary>
         /// Gets the protocol version number.
         /// </summary>
-        [DataMember(Name = "version")]
+        [JsonProperty(PropertyName = "version")]
         public string Version { get; set; }
 
         /// <summary>
         /// Gets the URI of the request.
         /// </summary>
-        [DataMember(Name = "uri")]
+        [JsonProperty(PropertyName = "uri")]
         public string Uri { get; set; }
 
         /// <summary>
         /// Gets the request query string.
         /// </summary>
-        [DataMember(Name = "queryString")]
+        [JsonProperty(PropertyName = "queryString")]
         public string QueryString { get; set; }
 
         /// <summary>
         /// Gets the HTTP method for the request.
         /// </summary>
-        [DataMember(Name = "method")]
+        [JsonProperty(PropertyName = "method")]
         public string Method { get; set; }
 
         /// <summary>
         /// Gets the port the request used.
         /// </summary>
-        [DataMember(Name = "port")]
+        [JsonProperty(PropertyName = "port")]
         public int Port { get; set; }
 
         /// <summary>
         /// Gets a list of HTTP headers for the request.
         /// </summary>
-        [DataMember(Name = "headers")]
+        [JsonProperty(PropertyName = "headers")]
         public List<Header> Headers { get; set; }
 
         /// <summary>
         /// Gets a list of parameters for the request.
         /// </summary>
-        [DataMember(Name = "parameters")]
+        [JsonProperty(PropertyName = "parameters")]
         public List<Parameter> Parameters { get; set; }
 
         /// <summary>
         /// Gets a list of Contrast REST endpoint URLs for this request.
         /// </summary>
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TraceRequestResponse
     {
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
 
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
-        [DataMember(Name = "http_request")]
+        [JsonProperty(PropertyName = "http_request")]
         public Snippet HttpRequest { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Score.cs
+++ b/contrast-rest-dotnet/Model/Score.cs
@@ -29,69 +29,69 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class Score
     {
         /// <summary>
         /// Grade
         /// </summary>
-        [DataMember(Name = "grade")]
+        [JsonProperty(PropertyName = "grade")]
         public int? Grade { get; set; }
 
         /// <summary>
         /// Letter grade
         /// </summary>
-        [DataMember(Name = "letter_grade")]
+        [JsonProperty(PropertyName = "letter_grade")]
         public string LetterGrade { get; set; }
 
         /// <summary>
         /// Library scoring type. Allowed values: DEFAULT, VULN
         /// </summary>
-        [DataMember(Name = "library_scoring_type")]
+        [JsonProperty(PropertyName = "library_scoring_type")]
         public string LibraryScoringType { get; set; }
 
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
 
         /// <summary>
         /// Overall scoring type
         /// </summary>
-        [DataMember(Name = "overall_scoring_type")]
+        [JsonProperty(PropertyName = "overall_scoring_type")]
         public string OverallScoringType { get; set; }
 
         /// <summary>
         /// Platform score
         /// </summary>
-        [DataMember(Name = "platform")]
+        [JsonProperty(PropertyName = "platform")]
         public ScoreMetricResource Platform { get; set; }
 
         /// <summary>
         /// Security score
         /// </summary>
-        [DataMember(Name = "security")]
+        [JsonProperty(PropertyName = "security")]
         public ScoreMetricResource Security { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class ScoreMetricResource
     {
         /// <summary>
         /// Grade
         /// </summary>
-        [DataMember(Name = "grade")]
+        [JsonProperty(PropertyName = "grade")]
         public int? Grade { get; set; }
 
         /// <summary>
         /// Letter grade
         /// </summary>
-        [DataMember(Name = "letter_grade")]
+        [JsonProperty(PropertyName = "letter_grade")]
         public string LetterGrade { get; set; }
 
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Server.cs
+++ b/contrast-rest-dotnet/Model/Server.cs
@@ -65,12 +65,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "assessPending")]
         public bool AssessPending { get; set; }
 
-        [JsonProperty(PropertyName = "assess_last_update")]
-        private long? AssessLastUpdateRawValue { get; set; }
-
         /// <summary>
         /// Last assess change time.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "assess_last_update")]
         public DateTime? AssessLastUpdate { get; set; }
 
         /// <summary>
@@ -103,12 +102,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "defend_sensors")]
         public bool DefendSensors { get; set; }
 
-        [JsonProperty(PropertyName = "defense_last_update")]
-        private long? DefenseLastUpdateRawValue { get; set; }
-
         /// <summary>
         /// Last defense change time.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "defense_last_update")]
         public DateTime? DefenseLastUpdate { get; set; }
 
         /// <summary>
@@ -123,20 +121,18 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "hostname")]
         public string Hostname { get; set; }
 
-        [JsonProperty(PropertyName = "lastActivity")]
-        private long LastActivityRawValue { get; set; }
-
         /// <summary>
         /// Gets the last time any activity was received from this server.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "lastActivity")]
         public DateTime? LastActivity { get; set; }
-
-        [JsonProperty(PropertyName = "last_startup")]
-        private long LastStartupRawValue { get; set; }
 
         /// <summary>
         /// Gets the last time this server was started or restarted.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "last_startup")]
         public DateTime? LastStartup{ get; set; }
 
         /// <summary>
@@ -222,15 +218,6 @@ namespace contrast_rest_dotnet.Model
         /// </summary>
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
-
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            AssessLastUpdate = DateTimeConverter.ConvertToDateTime(AssessLastUpdateRawValue);
-            DefenseLastUpdate = DateTimeConverter.ConvertToDateTime(DefenseLastUpdateRawValue);
-            LastStartup = DateTimeConverter.ConvertToDateTime(LastStartupRawValue);
-            LastActivity = DateTimeConverter.ConvertToDateTime(LastActivityRawValue);
-        }
     }
 
     [JsonObject]

--- a/contrast-rest-dotnet/Model/Server.cs
+++ b/contrast-rest-dotnet/Model/Server.cs
@@ -30,6 +30,7 @@
 using contrast_rest_dotnet.Serialization;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using System.Runtime.Serialization;
 
 namespace contrast_rest_dotnet.Model
@@ -37,34 +38,34 @@ namespace contrast_rest_dotnet.Model
     /// <summary>
     /// A server with the contrast agent installed.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Server
     {
         /// <summary>
         /// Agent version
         /// </summary>
-        [DataMember(Name = "agent_version")]
+        [JsonProperty(PropertyName = "agent_version")]
         public string AgentVersion { get; set; }
 
         /// <summary>
         /// Return the list of applications in this server.
         /// </summary>
-        [DataMember(Name = "applications")]
+        [JsonProperty(PropertyName = "applications")]
         public List<ContrastApplication> Applications { get; set; }
 
         /// <summary>
         /// If this server has assess enabled.
         /// </summary>
-        [DataMember(Name = "assess")]
+        [JsonProperty(PropertyName = "assess")]
         public bool Assess { get; set; }
 
         /// <summary>
         /// If the server is changing Assess on restart.
         /// </summary>
-        [DataMember(Name = "assessPending")]
+        [JsonProperty(PropertyName = "assessPending")]
         public bool AssessPending { get; set; }
 
-        [DataMember(Name = "assess_last_update")]
+        [JsonProperty(PropertyName = "assess_last_update")]
         private long? AssessLastUpdateRawValue { get; set; }
 
         /// <summary>
@@ -75,34 +76,34 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// If the assess sensors are active.
         /// </summary>
-        [DataMember(Name = "assess_sensonrs")]
+        [JsonProperty(PropertyName = "assess_sensonrs")]
         public bool AssessSensors { get; set; }
 
         /// <summary>
         /// Container
         /// </summary>
-        [DataMember(Name = "container")]
+        [JsonProperty(PropertyName = "container")]
         public string Container { get; set; }
 
         /// <summary>
         /// If server has Defend.
         /// </summary>
-        [DataMember(Name = "defend")]
+        [JsonProperty(PropertyName = "defend")]
         public bool Defend { get; set; }
 
         /// <summary>
         /// If server is changing Defend on restart.
         /// </summary>
-        [DataMember(Name = "defendPending")]
+        [JsonProperty(PropertyName = "defendPending")]
         public bool DefendPending { get; set; }
 
         /// <summary>
         /// If server has defend sensors active.
         /// </summary>
-        [DataMember(Name = "defend_sensors")]
+        [JsonProperty(PropertyName = "defend_sensors")]
         public bool DefendSensors { get; set; }
 
-        [DataMember(Name = "defense_last_update")]
+        [JsonProperty(PropertyName = "defense_last_update")]
         private long? DefenseLastUpdateRawValue { get; set; }
 
         /// <summary>
@@ -113,16 +114,16 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Server environment. Allowed values: DEVELOPMENT, QA, PRODUCTION.
         /// </summary>
-        [DataMember(Name = "environment")]
+        [JsonProperty(PropertyName = "environment")]
         public string Environment { get; set; }
 
         /// <summary>
         /// Gets the hostname of this server.
         /// </summary>
-        [DataMember(Name = "hostname")]
+        [JsonProperty(PropertyName = "hostname")]
         public string Hostname { get; set; }
 
-        [DataMember(Name = "lastActivity")]
+        [JsonProperty(PropertyName = "lastActivity")]
         private long LastActivityRawValue { get; set; }
 
         /// <summary>
@@ -130,7 +131,7 @@ namespace contrast_rest_dotnet.Model
         /// </summary>
         public DateTime? LastActivity { get; set; }
 
-        [DataMember(Name = "last_startup")]
+        [JsonProperty(PropertyName = "last_startup")]
         private long LastStartupRawValue { get; set; }
 
         /// <summary>
@@ -141,85 +142,85 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// If server s changing Log Enhancers on restart.
         /// </summary>
-        [DataMember(Name = "logEnhancerPending")]
+        [JsonProperty(PropertyName = "logEnhancerPending")]
         public bool LogEnhancerPending { get; set; }
 
         /// <summary>
         /// Security log level.
         /// </summary>
-        [DataMember(Name = "logLevel")]
+        [JsonProperty(PropertyName = "logLevel")]
         public string LogLevel { get; set; }
 
         /// <summary>
         /// Log path
         /// </summary>
-        [DataMember(Name = "logPath")]
+        [JsonProperty(PropertyName = "logPath")]
         public string LogPath { get; set; }
 
         /// <summary>
         /// Server name
         /// </summary>
-        [DataMember(Name = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// If server is changing any settings on restart.
         /// </summary>
-        [DataMember(Name = "noPending")]
+        [JsonProperty(PropertyName = "noPending")]
         public bool NoPending { get; set; }
 
         /// <summary>
         /// Number of applications on server.
         /// </summary>
-        [DataMember(Name = "num_apps")]
+        [JsonProperty(PropertyName = "num_apps")]
         public long? TotalApps { get; set; }
 
         /// <summary>
         /// If the agent on this server is out of date.
         /// </summary>
-        [DataMember(Name = "out_of_date")]
+        [JsonProperty(PropertyName = "out_of_date")]
         public bool OutOfDate { get; set; }
 
         /// <summary>
         /// Server path
         /// </summary>
-        [DataMember(Name = "path")]
+        [JsonProperty(PropertyName = "path")]
         public string Path { get; set; }
 
         /// <summary>
         /// Gets the ID for the server.
         /// </summary>
-        [DataMember(Name = "server_id")]
+        [JsonProperty(PropertyName = "server_id")]
         public long ServerId { get; set; }
 
         /// <summary>
         /// Server status. Allowed values: ONLINE, OFFLINE.
         /// </summary>
-        [DataMember(Name = "status")]
+        [JsonProperty(PropertyName = "status")]
         public string Status { get; set; }
 
         /// <summary>
         /// If Syslog is enabled.
         /// </summary>
-        [DataMember(Name = "syslog_enabled")]
+        [JsonProperty(PropertyName = "syslog_enabled")]
         public bool SyslogEnabled { get; set; }
 
         /// <summary>
         /// Syslog IP adress.
         /// </summary>
-        [DataMember(Name = "syslog_ip_address")]
+        [JsonProperty(PropertyName = "syslog_ip_address")]
         public string SyslogIpAddress { get; set; }
 
         /// <summary>
         /// List of tags.
         /// </summary>
-        [DataMember(Name = "tags")]
+        [JsonProperty(PropertyName = "tags")]
         public List<string> Tags { get; set; }
 
         /// <summary>
         /// Get this server's type.
         /// </summary>
-        [DataMember(Name = "type")]
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
 
         [OnDeserialized]
@@ -232,32 +233,32 @@ namespace contrast_rest_dotnet.Model
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class ServerResponse
     {
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
-        [DataMember(Name = "server")]
+        [JsonProperty(PropertyName = "server")]
         public Server Server { get; set; }
 
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class ServersResponse
     {
-        [DataMember(Name = "count")]
+        [JsonProperty(PropertyName = "count")]
         public long Count { get; set; }
 
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
-        [DataMember(Name = "servers")]
+        [JsonProperty(PropertyName = "servers")]
         public List<Server> Servers { get; set; }
 
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Snippet.cs
+++ b/contrast-rest-dotnet/Model/Snippet.cs
@@ -28,20 +28,20 @@
  */
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class Snippet
     {
-        [DataMember(Name = "text")]
+        [JsonProperty(PropertyName = "text")]
         public string Text { get; set; }
 
-        [DataMember(Name = "formattedText")]
+        [JsonProperty(PropertyName = "formattedText")]
         public string FormattedText { get; set; }
 
-        [DataMember(Name = "formattedTextVariables")]
+        [JsonProperty(PropertyName = "formattedTextVariables")]
         public Dictionary<string, string> FormattedTextVariables { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/StoryChapter.cs
+++ b/contrast-rest-dotnet/Model/StoryChapter.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace contrast_rest_dotnet.Model
 {
@@ -49,6 +50,7 @@ namespace contrast_rest_dotnet.Model
     [JsonObject]
     public class Chapter
     {
+        [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(PropertyName = "type")]
         public ChapterType Type { get; set; }
 

--- a/contrast-rest-dotnet/Model/StoryChapter.cs
+++ b/contrast-rest-dotnet/Model/StoryChapter.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2015, Contrast Security, Inc.
+ * Copyright (c) 2017, Contrast Security, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -27,26 +27,53 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    /// <summary>
-    /// Name=value pair for HTTP headers.
-    /// </summary>
-    [JsonObject]
-    public class Header
+    public enum ChapterType
     {
-        /// <summary>
-        /// Gets the name of the header.
-        /// </summary>
-        [JsonProperty(PropertyName = "name")]
-        public string Name { get; set; }
+        recreation,
+        location,
+        configuration,
+        dataflow,
+        outcome,
+        properties,
+        request,
+        risk,
+        source
+    }
 
-        /// <summary>
-        /// Gets the value of the header.
-        /// </summary>
-        [JsonProperty(PropertyName = "value")]
-        public string Value { get; set; }
+    [JsonObject]
+    public class Chapter
+    {
+        [JsonProperty(PropertyName = "type")]
+        public ChapterType Type { get; set; }
+
+        [JsonProperty(PropertyName = "introText")]
+        public string IntroText { get; set; }
+
+        [JsonProperty(PropertyName = "introTextFormat")]
+        public string IntroTextFormat { get; set; }
+
+        [JsonProperty(PropertyName = "introTextVariables")]
+        public Dictionary<string, string> IntroTextVariables { get; set; }
+
+        [JsonProperty(PropertyName = "body")]
+        public string Body { get; set; }
+
+        [JsonProperty(PropertyName = "bodyFormat")]
+        public string BodyFormat { get; set; }
+
+        [JsonProperty(PropertyName = "bodyFormatVariables")]
+        public Dictionary<string, string> BodyFormatVariables { get; set; }
+
+        [JsonProperty(PropertyName = "properties")]
+        public Dictionary<string, Property> Properties { get; set; }
+
+        [JsonProperty(PropertyName = "vector")]
+        private string Vector { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Trace.cs
+++ b/contrast-rest-dotnet/Model/Trace.cs
@@ -30,6 +30,7 @@
 using contrast_rest_dotnet.Serialization;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using System.Runtime.Serialization;
 
 namespace contrast_rest_dotnet.Model
@@ -37,73 +38,73 @@ namespace contrast_rest_dotnet.Model
     /// <summary>
     /// A vulnerability identified by Contrast.
     /// </summary>
-    [DataContract]
+    [JsonObject]
     public class Trace
     {
         /// <summary>
         /// Gets the unique ID for the trace.
         /// </summary>
-        [DataMember(Name = "uuid")]
+        [JsonProperty(PropertyName = "uuid")]
         public string Uuid { get; set; }
 
         /// <summary>
         /// List of application version tags
         /// </summary>
-        [DataMember(Name = "app_version_tags")]
+        [JsonProperty(PropertyName = "app_version_tags")]
         public List<string> AppVersionTags { get; set; }
 
         /// <summary>
         /// This trace Application
         /// </summary>
-        [DataMember(Name = "application")]
+        [JsonProperty(PropertyName = "application")]
         public ContrastApplication Application { get; set; }
 
         /// <summary>
         /// Period of Remediation Policy that Auto-Remediated this trace
         /// </summary>
-        [DataMember(Name = "auto_remediated_expiration_period")]
+        [JsonProperty(PropertyName = "auto_remediated_expiration_period")]
         public long? AutoRemediatedExpirationPeriod { get; set; }
 
-        [DataMember(Name = "card")]
+        [JsonProperty(PropertyName = "card")]
         public Card Card { get; set; }
 
         /// <summary>
         /// Gets this trace category
         /// </summary>
-        [DataMember(Name = "category")]
+        [JsonProperty(PropertyName = "category")]
         public string Category { get; set; }
 
         /// <summary>
         /// Gets this trace closed time
         /// </summary>
-        [DataMember(Name = "closed_time")]
+        [JsonProperty(PropertyName = "closed_time")]
         public long? ClosedTime { get; set; }
 
         /// <summary>
         /// Get this trace Confidence
         /// </summary>
-        [DataMember(Name = "confidence")]
+        [JsonProperty(PropertyName = "confidence")]
         public string Confidence { get; set; }
 
         /// <summary>
         /// Default Severity. Allowed values: NOTE, LOW, MEDIUM, HIGH, CRITICAL.
         /// </summary>
-        [DataMember(Name = "default_severity")]
+        [JsonProperty(PropertyName = "default_severity")]
         public string DefaultSeverity { get; set; }
 
         /// <summary>
         /// List of events
         /// </summary>
-        [DataMember(Name = "events")]
+        [JsonProperty(PropertyName = "events")]
         public List<TraceEvent> Events { get; set; }
 
         /// <summary>
         /// Gets this trace Evidence
         /// </summary>
-        [DataMember(Name = "evidence")]
+        [JsonProperty(PropertyName = "evidence")]
         public string Evidence { get; set; }
 
-        [DataMember(Name = "first_time_seen")]
+        [JsonProperty(PropertyName = "first_time_seen")]
         private long FirstTimeSeenRawValue { get; set; }
 
         /// <summary>
@@ -114,22 +115,22 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Gets whether this trace has a parent app or not.
         /// </summary>
-        [DataMember(Name = "hasParentApp")]
+        [JsonProperty(PropertyName = "hasParentApp")]
         public bool HasParentApp { get; set; }
 
         /// <summary>
         /// Gets this trace impact.
         /// </summary>
-        [DataMember(Name = "impact")]
+        [JsonProperty(PropertyName = "impact")]
         public string Impact { get; set; }
 
         /// <summary>
         /// Gets the language for the trace.
         /// </summary>
-        [DataMember(Name = "language")]
+        [JsonProperty(PropertyName = "language")]
         public string Language { get; set; }
 
-        [DataMember(Name = "last_time_seen")]
+        [JsonProperty(PropertyName = "last_time_seen")]
         private long LastTimeSeenRawValue { get; set; }
 
         /// <summary>
@@ -140,47 +141,47 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Gets this trace license. Allowed values: ReadOnly, Unlincensed, Licensed.
         /// </summary>
-        [DataMember(Name = "license")]
+        [JsonProperty(PropertyName = "license")]
         public string License { get; set; }
 
         /// <summary>
         /// Gets likelihood for this trace
         /// </summary>
-        [DataMember(Name = "likelihood")]
+        [JsonProperty(PropertyName = "likelihood")]
         public string Likelihood { get; set; }
 
         /// <summary>
         /// Gets a list of Contrast REST endpoint URLs for this trace.
         /// </summary>
         [Obsolete("Use the field from TraceFilterResponse object.")]
-        [DataMember(Name = "links")]
+        [JsonProperty(PropertyName = "links")]
         public List<Link> Links { get; set; }
 
         /// <summary>
         /// List of notes
         /// </summary>
-        [DataMember(Name = "notes")]
+        [JsonProperty(PropertyName = "notes")]
         public List<TraceNote> Notes { get; set; }
 
         /// <summary>
         /// Organization Name
         /// </summary>
-        [DataMember(Name = "organization_name")]
+        [JsonProperty(PropertyName = "organization_name")]
         public string OrganizationName { get; set; }
 
         /// <summary>
         /// Parent Application ID
         /// </summary>
-        [DataMember(Name = "parent_application")]
+        [JsonProperty(PropertyName = "parent_application")]
         public ContrastApplication ParentApplication { get; set; }
 
         /// <summary>
         /// Is reported to bug tacker
         /// </summary>
-        [DataMember(Name = "reported_to_bug_tracker")]
+        [JsonProperty(PropertyName = "reported_to_bug_tracker")]
         public bool ReportedToBugTracker { get; set; }
 
-        [DataMember(Name = "reported_to_bug_tracker_time")]
+        [JsonProperty(PropertyName = "reported_to_bug_tracker_time")]
         public long? ReportedToBugTrackerTimeRawValue { get; set; }
 
         /// <summary>
@@ -191,55 +192,55 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Gets the HTTP request that caused this trace to occur.
         /// </summary>
-        [DataMember(Name = "request")]
+        [JsonProperty(PropertyName = "request")]
         public Request Request { get; set; }
 
         /// <summary>
         /// Gets the rule-name for the vulnerability.
         /// </summary>
-        [DataMember(Name = "rule_name")]
+        [JsonProperty(PropertyName = "rule_name")]
         public string RuleName { get; set; }
 
-        [DataMember(Name = "servers")]
+        [JsonProperty(PropertyName = "servers")]
         public List<Server> Servers { get; set; }
 
         /// <summary>
         /// Gets the severity of this trace.
         /// </summary>
-        [DataMember(Name = "severity")]
+        [JsonProperty(PropertyName = "severity")]
         public string Severity { get; set; }
 
         /// <summary>
         /// Gets the status of this trace, like "Reported", "Verified", "Suspicious", etc.
         /// </summary>
-        [DataMember(Name = "status")]
+        [JsonProperty(PropertyName = "status")]
         public string Status { get; set; }
 
         /// <summary>
         /// Gets the sub status of this trace
         /// </summary>
-        [DataMember(Name = "sub_status")]
+        [JsonProperty(PropertyName = "sub_status")]
         public string SubStatus { get; set; }
 
         /// <summary>
         /// Gets the sub-title of the trace.
         /// </summary>
-        [DataMember(Name = "sub_title")]
+        [JsonProperty(PropertyName = "sub_title")]
         public string SubTitle { get; set; }
 
         /// <summary>
         /// Gets the title of the trace.
         /// </summary>
-        [DataMember(Name = "title")]
+        [JsonProperty(PropertyName = "title")]
         public string Title { get; set; }
 
         /// <summary>
         /// Gets the total traces received.
         /// </summary>
-        [DataMember(Name = "total_traces_received")]
+        [JsonProperty(PropertyName = "total_traces_received")]
         public int? TotalTracesReceived { get; set; }
 
-        [DataMember(Name = "visible")]
+        [JsonProperty(PropertyName = "visible")]
         public bool Visible { get; set; }
 
         [OnDeserialized]
@@ -251,10 +252,10 @@ namespace contrast_rest_dotnet.Model
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TraceNote
     {
-        [DataMember(Name = "creation")]
+        [JsonProperty(PropertyName = "creation")]
         private long? CreationRawValue { get; set; }
 
         /// <summary>
@@ -265,28 +266,28 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Creator name.
         /// </summary>
-        [DataMember(Name = "creator")]
+        [JsonProperty(PropertyName = "creator")]
         public string Creator { get; set; }
 
         /// <summary>
         /// Creator UUID.
         /// </summary>
-        [DataMember(Name = "creator_uuid")]
+        [JsonProperty(PropertyName = "creator_uuid")]
         public string CreatorUUID { get; set; }
 
         /// <summary>
         /// If this note is deletable.
         /// </summary>
-        [DataMember(Name = "deletable")]
+        [JsonProperty(PropertyName = "deletable")]
         public bool Deletable { get; set; }
 
         /// <summary>
         /// Note id.
         /// </summary>
-        [DataMember(Name = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
-        [DataMember(Name = "last_modification")]
+        [JsonProperty(PropertyName = "last_modification")]
         public long? LastModificationRawValue { get; set; }
 
         /// <summary>
@@ -297,19 +298,19 @@ namespace contrast_rest_dotnet.Model
         /// <summary>
         /// Last updater name.
         /// </summary>
-        [DataMember(Name = "last_updater")]
+        [JsonProperty(PropertyName = "last_updater")]
         public string LastUpdater { get; set; }
 
         /// <summary>
         /// Last updater UUID.
         /// </summary>
-        [DataMember(Name = "last_updater_uuid")]
+        [JsonProperty(PropertyName = "last_updater_uuid")]
         public string LastUpdaterUUID { get; set; }
 
         /// <summary>
         /// Note contents.
         /// </summary>
-        [DataMember(Name = "note")]
+        [JsonProperty(PropertyName = "note")]
         public string Note { get; set; }
 
         [OnDeserialized]
@@ -320,59 +321,59 @@ namespace contrast_rest_dotnet.Model
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TraceFilterResponse
     {
         /// <summary>
         /// Count
         /// </summary>
-        [DataMember(Name = "count")]
+        [JsonProperty(PropertyName = "count")]
         public long Count { get; set; }
 
         /// <summary>
         /// Number of Traces from a licensed app
         /// </summary>
-        [DataMember(Name = "licensedCount")]
+        [JsonProperty(PropertyName = "licensedCount")]
         public long LicensedCount { get; set; }
 
         /// <summary>
         /// List of messages
         /// </summary>
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
         /// <summary>
         /// Indicates whether API response was successful or not
         /// </summary>
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
 
         /// <summary>
         /// List of traces
         /// </summary>
-        [DataMember(Name = "traces")]
+        [JsonProperty(PropertyName = "traces")]
         public List<Trace> Traces { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TracesSearchResponse
     {
         /// <summary>
         /// List of messages
         /// </summary>
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
         /// <summary>
         /// Indicates whether API response was successful or not
         /// </summary>
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
 
         /// <summary>
         /// List of traces
         /// </summary>
-        [DataMember(Name = "traces")]
+        [JsonProperty(PropertyName = "traces")]
         public List<Trace> Traces { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/Trace.cs
+++ b/contrast-rest-dotnet/Model/Trace.cs
@@ -104,12 +104,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "evidence")]
         public string Evidence { get; set; }
 
-        [JsonProperty(PropertyName = "first_time_seen")]
-        private long FirstTimeSeenRawValue { get; set; }
-
         /// <summary>
         /// Time first seen
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "first_time_seen")]
         public DateTime? FirstTimeSeen { get; set; }
 
         /// <summary>
@@ -130,12 +129,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "language")]
         public string Language { get; set; }
 
-        [JsonProperty(PropertyName = "last_time_seen")]
-        private long LastTimeSeenRawValue { get; set; }
-
         /// <summary>
         /// Gets the last time the trace was reported.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "last_time_seen")]
         public DateTime? LastTimeSeen { get; set; }
 
         /// <summary>
@@ -181,12 +179,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "reported_to_bug_tracker")]
         public bool ReportedToBugTracker { get; set; }
 
-        [JsonProperty(PropertyName = "reported_to_bug_tracker_time")]
-        public long? ReportedToBugTrackerTimeRawValue { get; set; }
-
         /// <summary>
         /// Time reported to bug tracker
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "reported_to_bug_tracker_time")]
         public DateTime? ReportedToBugTrackerTime { get; set; }
 
         /// <summary>
@@ -242,25 +239,16 @@ namespace contrast_rest_dotnet.Model
 
         [JsonProperty(PropertyName = "visible")]
         public bool Visible { get; set; }
-
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            LastTimeSeen = DateTimeConverter.ConvertToDateTime(LastTimeSeenRawValue);
-            FirstTimeSeen = DateTimeConverter.ConvertToDateTime(FirstTimeSeenRawValue);
-            ReportedToBugTrackerTime = DateTimeConverter.ConvertToDateTime(ReportedToBugTrackerTimeRawValue);
-        }
     }
 
     [JsonObject]
     public class TraceNote
     {
-        [JsonProperty(PropertyName = "creation")]
-        private long? CreationRawValue { get; set; }
-
         /// <summary>
         /// Creation time.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "creation")]
         public DateTime? Creation { get; set; }
 
         /// <summary>
@@ -287,12 +275,11 @@ namespace contrast_rest_dotnet.Model
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
-        [JsonProperty(PropertyName = "last_modification")]
-        public long? LastModificationRawValue { get; set; }
-
         /// <summary>
         /// Last modification time.
         /// </summary>
+        [JsonConverter(typeof(EpochDateTimeConverter))]
+        [JsonProperty(PropertyName = "last_modification")]
         public DateTime? LastModification { get; set; }
 
         /// <summary>
@@ -312,13 +299,6 @@ namespace contrast_rest_dotnet.Model
         /// </summary>
         [JsonProperty(PropertyName = "note")]
         public string Note { get; set; }
-
-        [OnDeserialized]
-        private void OnDeserialized(StreamingContext context)
-        {
-            Creation = DateTimeConverter.ConvertToDateTime(CreationRawValue);
-            LastModification = DateTimeConverter.ConvertToDateTime(LastModificationRawValue);
-        }
     }
 
     [JsonObject]

--- a/contrast-rest-dotnet/Model/TraceBreakdown.cs
+++ b/contrast-rest-dotnet/Model/TraceBreakdown.cs
@@ -28,94 +28,94 @@
  */
 
 using System;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class TraceBreakdown
     {
         /// <summary>
         /// Number of vulnerabilities with status Confirmed
         /// </summary>
-        [DataMember(Name = "confirmed")]
+        [JsonProperty(PropertyName = "confirmed")]
         public long? Confirmed { get; set; }
 
         /// <summary>
         /// Number of critical vulnerabilities
         /// </summary>
-        [DataMember(Name = "criticals")]
+        [JsonProperty(PropertyName = "criticals")]
         public long? Criticals { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Fixed
         /// </summary>
-        [DataMember(Name = "fixed")]
+        [JsonProperty(PropertyName = "fixed")]
         public long? Fixed { get; set; }
 
         /// <summary>
         /// Number of high vulnerabilities
         /// </summary>
-        [DataMember(Name = "highs")]
+        [JsonProperty(PropertyName = "highs")]
         public long? HighVulns { get; set; }
 
         /// <summary>
         /// Number of low vulnerabilities
         /// </summary>
-        [DataMember(Name = "lows")]
+        [JsonProperty(PropertyName = "lows")]
         public long? LowVulns { get; set; }
 
         /// <summary>
         /// Number of medium vulnerabilities
         /// </summary>
-        [DataMember(Name = "meds")]
+        [JsonProperty(PropertyName = "meds")]
         public long? Mediums { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Not a problem
         /// </summary>
-        [DataMember(Name = "notProblem")]
+        [JsonProperty(PropertyName = "notProblem")]
         public long? NoProblemVulns { get; set; }
 
         /// <summary>
         /// Number of notes
         /// </summary>
-        [DataMember(Name = "notes")]
+        [JsonProperty(PropertyName = "notes")]
         public long? notes { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Remediated
         /// </summary>
-        [DataMember(Name = "remediated")]
+        [JsonProperty(PropertyName = "remediated")]
         public long? Remediated { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Reported
         /// </summary>
-        [DataMember(Name = "reported")]
+        [JsonProperty(PropertyName = "reported")]
         public long? Reported { get; set; }
         /// <summary>
         /// Number of vulnerabilities marked safe
         /// </summary>
-        [DataMember(Name = "safes")]
+        [JsonProperty(PropertyName = "safes")]
         public long? SafeVulns { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Suspicious
         /// </summary>
-        [DataMember(Name = "suspicious")]
+        [JsonProperty(PropertyName = "suspicious")]
         public long? Suspicious { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities
         /// </summary>
-        [DataMember(Name = "traces")]
+        [JsonProperty(PropertyName = "traces")]
         public long? Traces { get; set; }
 
         /// <summary>
         /// Number of triaged vulnerabilities
         /// </summary>
-        [DataMember(Name = "triaged")]
+        [JsonProperty(PropertyName = "triaged")]
         public long? Triaged { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/TraceEvent.cs
+++ b/contrast-rest-dotnet/Model/TraceEvent.cs
@@ -28,7 +28,7 @@
  */
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
@@ -36,129 +36,129 @@ namespace contrast_rest_dotnet.Model
     /// A collection of TraceEvents make up a vulnerability, or, "trace". They
     /// represent a method invocation that Contrast monitored.
     /// </summary>
-    [DataContract(Name="Event")]
+    [JsonObject]
     public class TraceEvent
     {
         /// <summary>
         /// Gets the event ID.
         /// </summary>
-        [DataMember(Name="eventId")]
+        [JsonProperty(PropertyName="eventId")]
         public string EventId { get; set; }
 
         /// <summary>
         /// Gets the event type.
         /// </summary>
-        [DataMember(Name = "type")]
+        [JsonProperty(PropertyName = "type")]
         public string EventType { get; set; }
 
         /// <summary>
         /// Gets the code context for the event.
         /// </summary>
-        [DataMember(Name = "codeContext")]
+        [JsonProperty(PropertyName = "codeContext")]
         public object CodeContext { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TraceEventSummary
     {
         /// <summary>
         /// Raw code creation.
         /// </summary>
-        [DataMember(Name = "codeView")]
+        [JsonProperty(PropertyName = "codeView")]
         public CodeView CodeView { get; set; }
 
         /// <summary>
         /// List of collapsed events
         /// </summary>
-        [DataMember(Name = "collapsedEvents")]
+        [JsonProperty(PropertyName = "collapsedEvents")]
         public List<TraceEventSummary> CollapsedEvents { get; set; }
 
         /// <summary>
         /// Data snapshot
         /// </summary>
-        [DataMember(Name = "dataView")]
+        [JsonProperty(PropertyName = "dataView")]
         public CodeView DataView { get; set; }
 
         /// <summary>
         /// Event description
         /// </summary>
-        [DataMember(Name = "description")]
+        [JsonProperty(PropertyName = "description")]
         public string Description { get; set; }
 
         /// <summary>
         /// Number of duplicated events collapsed.
         /// </summary>
-        [DataMember(Name = "dupes")]
+        [JsonProperty(PropertyName = "dupes")]
         public int? Dupes { get; set; }
 
         /// <summary>
         /// Event extra details.
         /// </summary>
-        [DataMember(Name = "extraDetails")]
+        [JsonProperty(PropertyName = "extraDetails")]
         public string ExtraDetails { get; set; }
 
         /// <summary>
         /// Event id.
         /// </summary>
-        [DataMember(Name = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
         /// If this event is important.
         /// </summary>
-        [DataMember(Name = "important")]
+        [JsonProperty(PropertyName = "important")]
         public bool Important { get; set; }
 
         /// <summary>
         /// Probable start location/
         /// </summary>
-        [DataMember(Name = "probableStartLocation")]
+        [JsonProperty(PropertyName = "probableStartLocation")]
         public CodeView ProbableStartLocation { get; set; }
 
         /// <summary>
         /// Event type.
         /// </summary>
-        [DataMember(Name = "type")]
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TraceEventSummaryResponse
     {
         /// <summary>
         /// List of events
         /// </summary>
-        [DataMember(Name = "events")]
+        [JsonProperty(PropertyName = "events")]
         public List<TraceEventSummary> Events { get; set; }
 
         /// <summary>
         /// Evidence
         /// </summary>
-        [DataMember(Name = "evidence")]
+        [JsonProperty(PropertyName = "evidence")]
         public string Evidence { get; set; }
 
         /// <summary>
         /// List of messages
         /// </summary>
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
         /// <summary>
         /// If events are shown.
         /// </summary>
-        [DataMember(Name = "showEvents")]
+        [JsonProperty(PropertyName = "showEvents")]
         public bool ShowEvents { get; set; }
 
         /// <summary>
         /// If evidence is shown.
         /// </summary>
-        [DataMember(Name = "showEvidence")]
+        [JsonProperty(PropertyName = "showEvidence")]
         public bool ShowEvidence { get; set; }
 
         /// <summary>
         /// Indicates whether API response was successful or not
         /// </summary>
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/TraceEventDetail.cs
+++ b/contrast-rest-dotnet/Model/TraceEventDetail.cs
@@ -28,107 +28,107 @@
  */
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class TraceEventDetail
     {
         /// <summary>
         /// [Optional] Class name
         /// </summary>
-        [DataMember(Name = "class")]
+        [JsonProperty(PropertyName = "class")]
         public string ClassName { get; set; }
 
         /// <summary>
         /// Last custom frame.
         /// </summary>
-        [DataMember(Name = "lastCustomFrame")]
+        [JsonProperty(PropertyName = "lastCustomFrame")]
         public long? LastCustomFrame { get; set; }
 
         /// <summary>
         /// [Optional] Method
         /// </summary>
-        [DataMember(Name = "method")]
+        [JsonProperty(PropertyName = "method")]
         public string Method { get; set; }
 
         /// <summary>
         /// [Optional] Object
         /// </summary>
-        [DataMember(Name = "object")]
+        [JsonProperty(PropertyName = "object")]
         public string Object { get; set; }
 
         /// <summary>
         /// If the object is being tracked.
         /// </summary>
-        [DataMember(Name = "objectTracked")]
+        [JsonProperty(PropertyName = "objectTracked")]
         public bool ObjectTracked { get; set; }
 
         /// <summary>
         /// List of parameters
         /// </summary>
-        [DataMember(Name = "parameters")]
+        [JsonProperty(PropertyName = "parameters")]
         public List<EventParameter> Parameters { get; set; }
 
         /// <summary>
         /// If the return is tracked.
         /// </summary>
-        [DataMember(Name = "returnTracked")]
+        [JsonProperty(PropertyName = "returnTracked")]
         public bool ReturnTracked { get; set; }
 
         /// <summary>
         /// [Optional] Return value.
         /// </summary>
-        [DataMember(Name = "returnValue")]
+        [JsonProperty(PropertyName = "returnValue")]
         public string ReturnValue { get; set; }
 
         /// <summary>
         /// List of stack traces.
         /// </summary>
-        [DataMember(Name = "stacktraces")]
+        [JsonProperty(PropertyName = "stacktraces")]
         public List<Stacktrace> StackTraces { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class EventParameter
     {
-        [DataMember(Name = "parameter")]
+        [JsonProperty(PropertyName = "parameter")]
         public string Parameter { get; set; }
 
-        [DataMember(Name = "tracked")]
+        [JsonProperty(PropertyName = "tracked")]
         public bool Tracked { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class Stacktrace
     {
-        [DataMember(Name = "description")]
+        [JsonProperty(PropertyName = "description")]
         public string Description { get; set; }
 
-        [DataMember(Name = "type")]
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class TraceEventDetailResponse
     {
         /// <summary>
         /// Event
         /// </summary>
-        [DataMember(Name = "event")]
+        [JsonProperty(PropertyName = "event")]
         public TraceEventDetail Event { get; set; }
 
         /// <summary>
         /// List of messges
         /// </summary>
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
         /// <summary>
         /// Indicates whether API response was successful or not
         /// </summary>
-        [DataMember(Name = "succes")]
+        [JsonProperty(PropertyName = "succes")]
         public bool Success { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Model/TraceStory.cs
+++ b/contrast-rest-dotnet/Model/TraceStory.cs
@@ -29,86 +29,58 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace contrast_rest_dotnet.Model
 {
-    [DataContract]
+    [JsonObject]
     public class TraceStory
     {
-        [DataMember(Name = "traceId")]
+        [JsonProperty(PropertyName = "traceId")]
         public string TraceId { get; set; }
 
-        [DataMember(Name = "chapters")]
+        [JsonProperty(PropertyName = "chapters")]
         public List<Chapter> Chapters { get; set; }
 
-        [DataMember(Name = "risk")]
+        [JsonProperty(PropertyName = "risk")]
         public Snippet Risk { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class Property
     {
-        [DataMember(Name = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
-        [DataMember(Name = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
     }
 
-    [DataContract]
-    public class Chapter
-    {
-        [DataMember(Name = "type")]
-        public String Type { get; set; }
-        
-        [DataMember(Name = "introText")]
-        public string IntroText { get; set; }
-
-        [DataMember(Name = "introTextFormat")]
-        public string IntroTextFormat { get; set; }
-
-        [DataMember(Name = "introTextVariables")]
-        public Dictionary<string,string> IntroTextVariables { get; set; }
-
-        [DataMember(Name = "body")]
-        public string Body { get; set; }
-
-        [DataMember(Name = "bodyFormat")]
-        public string BodyFormat { get; set; }
-
-        [DataMember(Name = "bodyFormatVariables")]
-        public Dictionary<string, string> BodyFormatVariables { get; set; }
-
-        [DataMember(Name = "propertyResources")]
-        public List<Property> Properties { get; set; }
-    }
-
-    [DataContract]
+    [JsonObject]
     public class TraceStoryResponse
     {
         /// <summary>
         /// Custom risk.
         /// </summary>
-        [DataMember(Name = "custom_risk")]
+        [JsonProperty(PropertyName = "custom_risk")]
         public Snippet CustomRisk { get; set; }
 
         /// <summary>
         /// List of messages.
         /// </summary>
-        [DataMember(Name = "messages")]
+        [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }
 
         /// <summary>
         /// Trace story.
         /// </summary>
-        [DataMember(Name = "story")]
+        [JsonProperty(PropertyName = "story")]
         public TraceStory Story { get; set; }
 
         /// <summary>
         /// Indicate whether API response was successful or not.
         /// </summary>
-        [DataMember(Name = "success")]
+        [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
 }

--- a/contrast-rest-dotnet/Properties/AssemblyInfo.cs
+++ b/contrast-rest-dotnet/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.8.0")]
-[assembly: AssemblyFileVersion("1.0.8.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/contrast-rest-dotnet/Serialization/EpochDateTimeConverter.cs
+++ b/contrast-rest-dotnet/Serialization/EpochDateTimeConverter.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * Copyright (c) 2015, Contrast Security, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * Neither the name of the Contrast Security, Inc. nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
+using Newtonsoft.Json;
+
+namespace contrast_rest_dotnet.Serialization
+{
+    public class EpochDateTimeConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DateTime) || objectType == typeof(DateTime?) || objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                if (objectType != typeof(DateTime?) && objectType != typeof(DateTimeOffset?))
+                    throw new JsonSerializationException($"Cannot convert null value to {objectType}");
+                return null;
+            }
+            else if (reader.TokenType == JsonToken.Integer)
+            {
+                long epochTime = (long)reader.Value;
+                DateTime dateTime = DateTimeConverter.ConvertFromEpochTime(epochTime);
+
+                if (((objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Nullable<>)) ? Nullable.GetUnderlyingType(objectType) : objectType) == typeof(DateTimeOffset))
+                {
+                    return new DateTimeOffset(dateTime);
+                }
+
+                return dateTime;
+            }
+            else
+            {
+                throw new JsonSerializationException("Must be a long integer value");
+            }
+
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is DateTime)
+            {
+                long epochTime = DateTimeConverter.ConvertToEpochTime((DateTime)value);
+                writer.WriteValue(epochTime);
+            }
+            else
+            {
+                if (!(value is DateTimeOffset))
+                {
+                    throw new JsonSerializationException("Expected date object value.");
+                }
+                var datetime = ((DateTimeOffset)value).ToUniversalTime().UtcDateTime;
+                writer.WriteValue(DateTimeConverter.ConvertToEpochTime(datetime));
+            }
+        }
+    }
+}

--- a/contrast-rest-dotnet/contrast-rest-dotnet.csproj
+++ b/contrast-rest-dotnet/contrast-rest-dotnet.csproj
@@ -40,6 +40,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -66,6 +70,7 @@
     <Compile Include="Model\Profile.cs" />
     <Compile Include="Model\Score.cs" />
     <Compile Include="Model\Snippet.cs" />
+    <Compile Include="Model\StoryChapter.cs" />
     <Compile Include="Model\TraceBreakdown.cs" />
     <Compile Include="Model\TraceEventDetail.cs" />
     <Compile Include="Model\TraceStory.cs" />
@@ -84,6 +89,9 @@
     <Compile Include="Serialization\DateTimeConverter.cs" />
     <Compile Include="TeamServerClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/contrast-rest-dotnet/contrast-rest-dotnet.csproj
+++ b/contrast-rest-dotnet/contrast-rest-dotnet.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Model\Trace.cs" />
     <Compile Include="Model\Parameter.cs" />
     <Compile Include="Serialization\DateTimeConverter.cs" />
+    <Compile Include="Serialization\EpochDateTimeConverter.cs" />
     <Compile Include="TeamServerClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/contrast-rest-dotnet/packages.config
+++ b/contrast-rest-dotnet/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+</packages>

--- a/contrast-rest-tests/ConverterTest.cs
+++ b/contrast-rest-tests/ConverterTest.cs
@@ -42,14 +42,14 @@ namespace sdk_tests
         [TestMethod]
         public void TestUnixTimeToDateTime()
         {
-            DateTime output = (DateTime) DateTimeConverter.ConvertToDateTime(TEST_TIME);
+            DateTime output = DateTimeConverter.ConvertFromEpochTime(TEST_TIME);
             Assert.AreEqual(TEST_DATE, output);
         }
 
         [TestMethod]
         public void TestDateTimeToUnixTime()
         {
-            long output = (long) DateTimeConverter.ConvertToUnixTime(TEST_DATE);
+            long output = DateTimeConverter.ConvertToEpochTime(TEST_DATE);
             Assert.AreEqual(TEST_TIME, output);
         }
     }

--- a/contrast-rest-tests/ConverterTest.cs
+++ b/contrast-rest-tests/ConverterTest.cs
@@ -1,4 +1,33 @@
-﻿using System;
+﻿/*
+ * Copyright (c) 2015, Contrast Security, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * Neither the name of the Contrast Security, Inc. nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using contrast_rest_dotnet.Serialization;
 

--- a/contrast-rest-tests/TeamServerClientTest.cs
+++ b/contrast-rest-tests/TeamServerClientTest.cs
@@ -119,7 +119,7 @@ namespace sdk_tests
                         }";
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/orgId/applications/")).Returns(
-                new MemoryStream( Encoding.Unicode.GetBytes(json) )
+                new MemoryStream( Encoding.UTF8.GetBytes(json) )
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -181,7 +181,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/orgId/applications/arbitraryId/libraries")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(libraryJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(libraryJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -331,7 +331,7 @@ namespace sdk_tests
                                     }";
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/" + orgId + "/orgtraces/filter")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(dataFlowTraceJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(dataFlowTraceJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -421,7 +421,7 @@ namespace sdk_tests
             DateTime expectedDate = new DateTime(1970, 1, 1).AddMilliseconds(1461239904769);
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/" + orgId + "/orgtraces/filter")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(configTraceJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(configTraceJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -490,7 +490,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/" + orgId + "/traces/" + appId +"/filter")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(configTraceJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(configTraceJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -558,7 +558,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/" + orgId + "/servertraces/" + serverId +"/filter")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(configTraceJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(configTraceJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -707,7 +707,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/orgId/traces/traceId/events/summary")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(eventSummaryJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(eventSummaryJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -787,7 +787,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/orgId/traces/traceId/events/12/details")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(detailsJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(detailsJson))
                 );
 
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
@@ -815,7 +815,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/orgId/traces/traceId/httprequest")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(httpJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(httpJson))
                 );
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
             var httpRequestResponse = teamServerClient.GetTraceHttpRequest("orgId", "traceId");
@@ -884,7 +884,7 @@ namespace sdk_tests
 
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/orgId/traces/traceId/story")).Returns(
-                new MemoryStream(Encoding.Unicode.GetBytes(storyJson))
+                new MemoryStream(Encoding.UTF8.GetBytes(storyJson))
                 );
             var teamServerClient = new TeamServerClient(mockSdkHttpClient.Object);
             var storyResponse = teamServerClient.GetTraceStory("orgId", "traceId");
@@ -892,11 +892,11 @@ namespace sdk_tests
             Assert.AreEqual(3, storyResponse.Story.Chapters.Count);
 
             var chapter = storyResponse.Story.Chapters[0];
-            Assert.AreEqual("source", chapter.Type);
+            Assert.AreEqual(ChapterType.source, chapter.Type);
             Assert.AreEqual("We tracked the following data from \"name\" Parameter:", chapter.IntroText);
 
             chapter = storyResponse.Story.Chapters[1];
-            Assert.AreEqual("location", chapter.Type);
+            Assert.AreEqual(ChapterType.location, chapter.Type);
             Assert.AreEqual("...which was accessed within the following code:", chapter.IntroTextFormat);
 
             Assert.AreEqual(0, storyResponse.Story.Risk.FormattedTextVariables.Count);

--- a/contrast-rest-tests/TeamServerClientTest.cs
+++ b/contrast-rest-tests/TeamServerClientTest.cs
@@ -418,7 +418,7 @@ namespace sdk_tests
                                       ]
                                     }";
 
-            DateTime expectedDate = new DateTime(1970, 1, 1).AddMilliseconds(1461239904769);
+            DateTime expectedDate = new DateTime(1970, 1, 1, 0, 0, 0).AddMilliseconds(1461239904769);
             var mockSdkHttpClient = new Mock<IContrastRestClient>();
             mockSdkHttpClient.Setup(client => client.GetResponseStream("api/ng/" + orgId + "/orgtraces/filter")).Returns(
                 new MemoryStream(Encoding.UTF8.GetBytes(configTraceJson))


### PR DESCRIPTION
* Changed JSON Serializer. Now it uses NewtonSoft.JSON which fixes problems with dictionaries.
* Updated all models with new annotations.
* Updated Chapter class structure so properties are correctly deserialized.
* Chapter now uses a enum for type field. This should make more clear what the allowed values are.

## Notes

* TeamServerClient tests were updated to use UTF-8 instead of Unicode.
* Updated SDK version to 2.0.0.0 (due to the all changes that have been done until now).