### PR TITLE
Normalized Public Api Contract

### DIFF
--- a/Contrast.ApiClient.sln.DotSettings
+++ b/Contrast.ApiClient.sln.DotSettings
@@ -32,4 +32,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</s:
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=85DDFD8642DA8E469F4E239D0A32A1AE/AbsolutePath/@EntryValue">D:\Development\tmp\contrast-sdk-dotnet\Contrast.ApiClient.sln.DotSettings</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=85DDFD8642DA8E469F4E239D0A32A1AE/RelativePath/@EntryValue"></s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File85DDFD8642DA8E469F4E239D0A32A1AE/@KeyIndexDefined">True</s:Boolean>
-	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File85DDFD8642DA8E469F4E239D0A32A1AE/RelativePriority/@EntryValue">1</s:Double></wpf:ResourceDictionary>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File85DDFD8642DA8E469F4E239D0A32A1AE/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=freemium/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Remediated/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Triaged/@EntryIndexedValue">True</s:Boolean>
+	</wpf:ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,63 @@ The 3.X line of packages has a few changes from the 2.X line that you might need
 * Removed the method `TeamServerClient.CheckForTrace`.
 * Renamed `TeamServerClient` to `Client`.
 * Removed deprecated `Endpoints` class.
+* Renamed the following symbols:
+
+```
+AgentType.Java1_5 -> AgentType.Java15
+
+Client.GetApplicationTraceFilterSubfilters -> Client.GetApplicationTraceFilterSubFilters
+Client.GetServerTraceFilterSubfilters -> Client.GetServerTraceFilterSubFilters
+
+ContrastRestClient.PostApplicatonSpecificMessage -> ContrastRestClient.PostApplicationSpecificMessage
+IContrastRestClient.PostApplicatonSpecificMessage -> IContrastRestClient.PostApplicationSpecificMessage
+
+LineFragment.value -> LineFragment.Value
+
+ContrastApplication.AppID -> ContrastApplication.AppId
+ContrastApplication.Stauts -> ContrastApplication.Status
+
+Organization.name -> Organization.Name
+Organization.shortname -> Organization.ShortName
+Organization.timezone -> Organization.Timezone
+Organization.organization_uuid -> Organization.OrganizationId
+Organization.AppsOnboarded -> Organization.AppsOnBoarded
+Organization.IsSuperadmin -> Organization.IsSuperAdmin
+Organization.Superadmin -> Organization.SuperAdmin
+
+OrganizationResponse.success -> OrganizationResponse.Organizations
+OrganizationResponse.count -> OrganizationResponse.Count
+OrganizationResponse.org_disabled -> OrganizationResponse.OrganizationDisabled
+
+DefaultOrganizationResponse.org_disabled -> DefaultOrganizationResponse.Success
+DefaultOrganizationResponse.messages -> DefaultOrganizationResponse.Messages
+DefaultOrganizationResponse.organization -> DefaultOrganizationResponse.Organization
+DefaultOrganizationResponse.roles -> DefaultOrganizationResponse.Roles
+DefaultOrganizationResponse.enterprise -> DefaultOrganizationResponse.Enterprise
+
+Trace.Uuid -> Trace.Id
+TraceNote.CreatorUUID -> TraceNote.CreatorId
+TraceNote.LastUpdaterUUID -> TraceNote.LastUpdaterId
+
+TraceBreakdown.Confirmed -> TraceBreakdown.ConfirmedVulnerabilities
+TraceBreakdown.Criticals -> TraceBreakdown.CriticalVulnerabilities
+TraceBreakdown.Fixed -> TraceBreakdown.FixedVulnerabilities
+TraceBreakdown.HighVulns -> TraceBreakdown.HighVulnerabilities
+TraceBreakdown.LowVulns -> TraceBreakdown.LowVulnerabilities
+TraceBreakdown.Mediums -> TraceBreakdown.MediumVulnerabilities
+TraceBreakdown.NoProblemVulns -> TraceBreakdown.NoProblemVulnerabilities
+TraceBreakdown.notes -> TraceBreakdown.Notes
+TraceBreakdown.SafeVulns -> TraceBreakdown.SafeVulnerabilities
+
+TraceStatus.CONFIRMED_STATUS -> TraceStatus.Confirmed
+TraceStatus.SUSPICIOUS_STATUS -> TraceStatus.Suspicious
+TraceStatus.NOT_A_PROBLEM_STATUS -> TraceStatus.NotAProblem
+TraceStatus.REMEDIATED_STATUS -> TraceStatus.Remediated
+TraceStatus.REPORTED_STATUS -> TraceStatus.Reported
+TraceStatus.FIXED_STATUS -> TraceStatus.Fixed
+
+TraceMarkStatusRequest.Substatus -> TraceMarkStatusRequest.SubStatus
+```
 
 ## Contrast API Credentials
 To access the API, you'll first need access Contrast (https://app.contrastsecurity.com/Contrast/login.html) or an on-premises installation of Contrast.

--- a/examples/SampleContrastClient/Program.cs
+++ b/examples/SampleContrastClient/Program.cs
@@ -55,15 +55,15 @@ namespace SampleContrastClient
 
                 var orgs = client.GetOrganizations();
                 Console.WriteLine("User is associated with {0} orgs. {1}", orgs.Count,
-                    (orgs.Count > 0 ? "First Organization: " + orgs[0].name : string.Empty));
+                    (orgs.Count > 0 ? "First Organization: " + orgs[0].Name : string.Empty));
 
                 if (orgs.Count > 0)
                 {
-                    _organizationId = orgs[0].organization_uuid;
+                    _organizationId = orgs[0].OrganizationId;
                 }
 
                 var defaultOrg = client.GetDefaultOrganization();
-                Console.WriteLine("User's default org is:{0}({1})", defaultOrg.name, defaultOrg.organization_uuid);
+                Console.WriteLine("User's default org is:{0}({1})", defaultOrg.Name, defaultOrg.OrganizationId);
 
                 var serverResponse = client.GetServers(_organizationId);
                 if (serverResponse != null)
@@ -80,7 +80,7 @@ namespace SampleContrastClient
                 if (appsResponse != null && appsResponse.Applications.Count > 0)
                 {
                     var apps = appsResponse.Applications;
-                    string appId = apps[0].AppID;
+                    string appId = apps[0].AppId;
                     string appName = apps[0].Name;
                     Console.WriteLine("Retrieving traces for the first application: {0} ({1}", appName, appId);
 

--- a/src/ContrastRestClient/Client.cs
+++ b/src/ContrastRestClient/Client.cs
@@ -179,7 +179,7 @@ namespace Contrast
                 case AgentType.Java:
                     agentEndpoint = String.Format(NgEndpoints.ENGINE_JAVA, organizationId, profileName);
                     break;
-                case AgentType.Java1_5:
+                case AgentType.Java15:
                     agentEndpoint = String.Format(NgEndpoints.ENGINE_JAVA1_5, organizationId, profileName);
                     break;
                 case AgentType.Node:
@@ -313,8 +313,8 @@ namespace Contrast
         /// <returns>A TraceSearchResponse object which contains a list of all the traces with the given UUID.</returns>
         public TracesSearchResponse GetTracesByUuid(string organizationId, string traceUuid)
         {
-            string endpoit = String.Format(NgEndpoints.TRACE, organizationId, traceUuid);
-            return GetResponseAndDeserialize<TracesSearchResponse>(endpoit);
+            string endpoint = String.Format(NgEndpoints.TRACE, organizationId, traceUuid);
+            return GetResponseAndDeserialize<TracesSearchResponse>(endpoint);
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace Contrast
         public List<Organization> GetOrganizations()
         {
             var organizationResponse = GetResponseAndDeserialize<OrganizationResponse>(NgEndpoints.ORGANIZATIONS);
-            return organizationResponse.organizations;
+            return organizationResponse.Organizations;
         }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace Contrast
         {
             string endpoint = NgEndpoints.DEFAULT_ORGANIZATION;
             var response = GetResponseAndDeserialize<DefaultOrganizationResponse>(endpoint);
-            return response.organization;
+            return response.Organization;
         }
 
         /// <summary>
@@ -541,7 +541,7 @@ namespace Contrast
         /// <param name="type">Filter type. Allowed values: appversiontags,workflow,servers,time,url,vulntype,servers,security-standard.</param>
         /// <param name="filter">Query params that can be added to request.</param>
         /// <returns>A TraceFilterCatalogDetailsResponse that contains all the available subfilters.</returns>
-        public TraceFilterCatalogDetailsResponse GetApplicationTraceFilterSubfilters(string organizationId, string appId, TraceFilterType type, TraceFilter filter)
+        public TraceFilterCatalogDetailsResponse GetApplicationTraceFilterSubFilters(string organizationId, string appId, TraceFilterType type, TraceFilter filter)
         {
             string endpoint = String.Format(NgEndpoints.APPLICATION_TRACE_FILTERS, organizationId, appId, getTraceFilterTypeValue(type));
             if (filter != null)
@@ -557,7 +557,7 @@ namespace Contrast
         /// <param name="type">Filter type. Allowed values: modules,workflow,servers,time,url,vulntype,security-standard.</param>
         /// <param name="filter">Query params that can be added to request.</param>
         /// <returns>A TraceFilterCatalogDetailsResponse that contains all the available subfilters.</returns>
-        public TraceFilterCatalogDetailsResponse GetServerTraceFilterSubfilters(string organizationId, long serverId, TraceFilterType type, TraceFilter filter)
+        public TraceFilterCatalogDetailsResponse GetServerTraceFilterSubFilters(string organizationId, long serverId, TraceFilterType type, TraceFilter filter)
         {
             string endpoint = String.Format(NgEndpoints.SERVER_TRACE_FILTERS, organizationId, serverId, getTraceFilterTypeValue(type));
             if (filter != null)
@@ -571,7 +571,7 @@ namespace Contrast
         /// <param name="organizationId">Organization UUID.</param>
         /// <param name="traceUuid">Trace UUID.</param>
         /// <param name="tag">The tag to be deleted.</param>
-        /// <returns>A TagsResponse object which indicates wheter the operation was successful or not.</returns>
+        /// <returns>A TagsResponse object which indicates whether the operation was successful or not.</returns>
         public TagsResponse DeleteTraceTag(string organizationId, string traceUuid, string tag)
         {
             string endpoint = String.Format(NgEndpoints.DELETE_TRACE_TAG, organizationId, traceUuid);

--- a/src/ContrastRestClient/Http/ContrastRestClient.cs
+++ b/src/ContrastRestClient/Http/ContrastRestClient.cs
@@ -70,7 +70,7 @@ namespace Contrast.Http
             }
         }
 
-        public System.Net.Http.HttpResponseMessage PostApplicatonSpecificMessage(string endpoint, string postBody, string application )
+        public System.Net.Http.HttpResponseMessage PostApplicationSpecificMessage(string endpoint, string postBody, string application )
         {
             var headers = new List<Tuple<string, string>>();
             headers.Add( new Tuple<string,string>( "Application", application ) );

--- a/src/ContrastRestClient/Http/IContrastRestClient.cs
+++ b/src/ContrastRestClient/Http/IContrastRestClient.cs
@@ -36,7 +36,7 @@ namespace Contrast.Http
     public interface IContrastRestClient : IDisposable
     {
         System.IO.Stream GetResponseStream(string apiEndpoint);
-        HttpResponseMessage PostApplicatonSpecificMessage(string endpoint, string postBody, string application);
+        HttpResponseMessage PostApplicationSpecificMessage(string endpoint, string postBody, string application);
         HttpResponseMessage PostMessage(string endpoint, string postBody, List<Tuple<string,string>> additionalHeaders );
         HttpResponseMessage PutMessage(string endpoint, string requestBody, List<Tuple<string, string>> additionalHeaders);
         HttpResponseMessage DeleteMessage(string endpoint);

--- a/src/ContrastRestClient/Http/TraceFilter.cs
+++ b/src/ContrastRestClient/Http/TraceFilter.cs
@@ -36,7 +36,7 @@ namespace Contrast.Http
     public class TraceFilter
     {
         /// <summary>
-        /// Filte text.
+        /// Filter text.
         /// </summary>
         public string FilterText { get; set; }
         public DateTime? StartDate { get; set; }

--- a/src/ContrastRestClient/Model/AgentType.cs
+++ b/src/ContrastRestClient/Model/AgentType.cs
@@ -41,7 +41,7 @@ namespace Contrast.Model
         /// <summary>
         /// Java 1.5 engine type
         /// </summary>
-        Java1_5,
+        Java15,
         /// <summary>
         /// .NET engine type
         /// </summary>

--- a/src/ContrastRestClient/Model/CodeView.cs
+++ b/src/ContrastRestClient/Model/CodeView.cs
@@ -77,6 +77,6 @@ namespace Contrast.Model
         /// Fragment content.
         /// </summary>
         [JsonProperty(PropertyName = "value")]
-        public string value { get; set; }
+        public string Value { get; set; }
     }
 }

--- a/src/ContrastRestClient/Model/ContrastApplication.cs
+++ b/src/ContrastRestClient/Model/ContrastApplication.cs
@@ -45,7 +45,7 @@ namespace Contrast.Model
         /// Gets the ID of this application, which is a long, alphanumeric token.
         /// </summary>
         [JsonProperty(PropertyName="app_id")]
-        public string AppID { get; set; }
+        public string AppId { get; set; }
 
         /// <summary>
         /// If the application is archived
@@ -243,7 +243,7 @@ namespace Contrast.Model
         /// Application status
         /// </summary>
         [JsonProperty(PropertyName = "status")]
-        public string Stauts { get; set; }
+        public string Status { get; set; }
 
         /// <summary>
         /// List of tags

--- a/src/ContrastRestClient/Model/Organization.cs
+++ b/src/ContrastRestClient/Model/Organization.cs
@@ -46,21 +46,26 @@ namespace Contrast.Model
         /// <summary>
         /// Organization name
         /// </summary>
-        public string name { get; set; }
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
 
-        public string shortname { get; set; }
+        [JsonProperty(PropertyName = "shortname")]
+        public string ShortName { get; set; }
 
         /// <summary>
         /// Organization time zone
         /// </summary>
-        public string timezone { get; set; }
+        [JsonProperty(PropertyName = "timezone")]
+        public string Timezone { get; set; }
 
-        public List<Link> links { get; set; }
+        [JsonProperty(PropertyName = "links")]
+        public List<Link> Links { get; set; }
 
         /// <summary>
         /// Organization ID
         /// </summary>
-        public string organization_uuid { get; set; }
+        [JsonProperty(PropertyName = "organization_uuid")]
+        public string OrganizationId { get; set; }
 
         /// <summary>
         /// Account ID
@@ -69,10 +74,10 @@ namespace Contrast.Model
         public String AccountId { get; set; }
 
         /// <summary>
-        /// Number of applications onboarded
+        /// Number of applications on-boarded
         /// </summary>
         [JsonProperty(PropertyName = "apps_onboarded")]
-        public long? AppsOnboarded { get; set; }
+        public long? AppsOnBoarded { get; set; }
 
         /// <summary>
         /// Auto license assessment
@@ -81,7 +86,7 @@ namespace Contrast.Model
         public bool AutoLicenseAssessment { get; set; }
 
         /// <summary>
-        /// Auto license protetion
+        /// Auto license protection
         /// </summary>
         [JsonProperty(PropertyName = "auto_license_protection")]
         public bool AutoLicenseProtection { get; set; }
@@ -106,10 +111,10 @@ namespace Contrast.Model
         public bool? IsGuest { get; set; }
 
         /// <summary>
-        /// Is a Superadmin Organization
+        /// Is a SuperAdmin Organization
         /// </summary>
         [JsonProperty(PropertyName = "is_superadmin")]
-        public bool? IsSuperadmin { get; set; }
+        public bool? IsSuperAdmin { get; set; }
 
         /// <summary>
         /// Has user protect enabled in this organization?
@@ -142,7 +147,7 @@ namespace Contrast.Model
         public List<ServerEnvironment> ServerEnvironments { get; set; }
 
         [JsonProperty(PropertyName = "superadmin")]
-        public bool? Superadmin { get; set; }
+        public bool? SuperAdmin { get; set; }
 
         /// <summary>
         /// Organization date format
@@ -159,18 +164,32 @@ namespace Contrast.Model
 
     public class OrganizationResponse
     {
-        public List<Organization> organizations { get; set; }
-        public int count { get; set; }
-        public List<object> org_disabled { get; set; }
+        [JsonProperty(PropertyName = "organizations")]
+        public List<Organization> Organizations { get; set; }
+
+        [JsonProperty(PropertyName = "count")]
+        public int Count { get; set; }
+
+        [JsonProperty(PropertyName = "org_disabled")]
+        public List<object> OrganizationDisabled { get; set; }
     }
 
     public class DefaultOrganizationResponse
     {
-        public bool success { get; set; }
-        public List<string> messages { get; set; }
-        public Organization organization { get; set; }
-        public List<string> roles { get; set; }
-        public bool enterprise { get; set; }
+        [JsonProperty(PropertyName = "success")]
+        public bool Success { get; set; }
+
+        [JsonProperty(PropertyName = "messages")]
+        public List<string> Messages { get; set; }
+
+        [JsonProperty(PropertyName = "organization")]
+        public Organization Organization { get; set; }
+
+        [JsonProperty(PropertyName = "roles")]
+        public List<string> Roles { get; set; }
+
+        [JsonProperty(PropertyName = "enterprise")]
+        public bool Enterprise { get; set; }
     }
 
     /// <summary>
@@ -196,5 +215,4 @@ namespace Contrast.Model
         [JsonProperty(PropertyName = "success")]
         public bool Success { get; set; }
     }
-
 }

--- a/src/ContrastRestClient/Model/Server.cs
+++ b/src/ContrastRestClient/Model/Server.cs
@@ -201,7 +201,7 @@ namespace Contrast.Model
         public bool SyslogEnabled { get; set; }
 
         /// <summary>
-        /// Syslog IP adress.
+        /// Syslog IP address.
         /// </summary>
         [JsonProperty(PropertyName = "syslog_ip_address")]
         public string SyslogIpAddress { get; set; }

--- a/src/ContrastRestClient/Model/Trace.cs
+++ b/src/ContrastRestClient/Model/Trace.cs
@@ -44,7 +44,7 @@ namespace Contrast.Model
         /// Gets the unique ID for the trace.
         /// </summary>
         [JsonProperty(PropertyName = "uuid")]
-        public string Uuid { get; set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// List of application version tags
@@ -173,13 +173,13 @@ namespace Contrast.Model
         public ContrastApplication ParentApplication { get; set; }
 
         /// <summary>
-        /// Is reported to bug tacker
+        /// Is reported to (b)ug tacker
         /// </summary>
         [JsonProperty(PropertyName = "reported_to_bug_tracker")]
         public bool ReportedToBugTracker { get; set; }
 
         /// <summary>
-        /// Time reported to bug tracker
+        /// Time reported to (b)ug tracker
         /// </summary>
         [JsonConverter(typeof(EpochDateTimeConverter))]
         [JsonProperty(PropertyName = "reported_to_bug_tracker_time")]
@@ -260,7 +260,7 @@ namespace Contrast.Model
         /// Creator UUID.
         /// </summary>
         [JsonProperty(PropertyName = "creator_uuid")]
-        public string CreatorUUID { get; set; }
+        public string CreatorId { get; set; }
 
         /// <summary>
         /// If this note is deletable.
@@ -291,7 +291,7 @@ namespace Contrast.Model
         /// Last updater UUID.
         /// </summary>
         [JsonProperty(PropertyName = "last_updater_uuid")]
-        public string LastUpdaterUUID { get; set; }
+        public string LastUpdaterId { get; set; }
 
         /// <summary>
         /// Note contents.

--- a/src/ContrastRestClient/Model/TraceBreakdown.cs
+++ b/src/ContrastRestClient/Model/TraceBreakdown.cs
@@ -38,49 +38,49 @@ namespace Contrast.Model
         /// Number of vulnerabilities with status Confirmed
         /// </summary>
         [JsonProperty(PropertyName = "confirmed")]
-        public long? Confirmed { get; set; }
+        public long? ConfirmedVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of critical vulnerabilities
         /// </summary>
         [JsonProperty(PropertyName = "criticals")]
-        public long? Criticals { get; set; }
+        public long? CriticalVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Fixed
         /// </summary>
         [JsonProperty(PropertyName = "fixed")]
-        public long? Fixed { get; set; }
+        public long? FixedVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of high vulnerabilities
         /// </summary>
         [JsonProperty(PropertyName = "highs")]
-        public long? HighVulns { get; set; }
+        public long? HighVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of low vulnerabilities
         /// </summary>
         [JsonProperty(PropertyName = "lows")]
-        public long? LowVulns { get; set; }
+        public long? LowVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of medium vulnerabilities
         /// </summary>
         [JsonProperty(PropertyName = "meds")]
-        public long? Mediums { get; set; }
+        public long? MediumVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Not a problem
         /// </summary>
         [JsonProperty(PropertyName = "notProblem")]
-        public long? NoProblemVulns { get; set; }
+        public long? NoProblemVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of notes
         /// </summary>
         [JsonProperty(PropertyName = "notes")]
-        public long? notes { get; set; }
+        public long? Notes { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Remediated
@@ -93,11 +93,12 @@ namespace Contrast.Model
         /// </summary>
         [JsonProperty(PropertyName = "reported")]
         public long? Reported { get; set; }
+
         /// <summary>
         /// Number of vulnerabilities marked safe
         /// </summary>
         [JsonProperty(PropertyName = "safes")]
-        public long? SafeVulns { get; set; }
+        public long? SafeVulnerabilities { get; set; }
 
         /// <summary>
         /// Number of vulnerabilities with status Suspicious

--- a/src/ContrastRestClient/Model/TraceEventDetail.cs
+++ b/src/ContrastRestClient/Model/TraceEventDetail.cs
@@ -138,7 +138,7 @@ namespace Contrast.Model
         public TraceEventDetail Event { get; set; }
 
         /// <summary>
-        /// List of messges
+        /// List of messages
         /// </summary>
         [JsonProperty(PropertyName = "messages")]
         public List<string> Messages { get; set; }

--- a/src/ContrastRestClient/Model/TraceStatus.cs
+++ b/src/ContrastRestClient/Model/TraceStatus.cs
@@ -38,12 +38,12 @@ namespace Contrast.Model
     /// </summary>
     public static class TraceStatus
     {
-        public const string CONFIRMED_STATUS = "Confirmed";
-        public const string SUSPICIOUS_STATUS = "Suspicious";
-        public const string NOT_A_PROBLEM_STATUS = "Not a Problem";
-        public const string REMEDIATED_STATUS = "Remediated";
-        public const string REPORTED_STATUS = "Reported";
-        public const string FIXED_STATUS = "Fixed";
+        public const string Confirmed = "Confirmed";
+        public const string Suspicious = "Suspicious";
+        public const string NotAProblem = "Not a Problem";
+        public const string Remediated = "Remediated";
+        public const string Reported = "Reported";
+        public const string Fixed = "Fixed";
     }
 
     [JsonObject]
@@ -64,7 +64,7 @@ namespace Contrast.Model
         /// Subs status
         /// </summary>
         [JsonProperty(PropertyName = "substatus")]
-        public string Substatus { get; set; }
+        public string SubStatus { get; set; }
 
         /// <summary>
         /// Note

--- a/src/ContrastRestClient/Serialization/DateTimeConverter.cs
+++ b/src/ContrastRestClient/Serialization/DateTimeConverter.cs
@@ -33,7 +33,7 @@ namespace Contrast.Serialization
 {
     public static class DateTimeConverter 
     {
-        private static readonly long epochMilliseconds = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
+        private static readonly long EpochMilliseconds = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks / TimeSpan.TicksPerMillisecond;
 
         /// <summary>
         /// Converts a Unix time (or epoch) representation to a DateTime object with UTC timezone.
@@ -42,7 +42,7 @@ namespace Contrast.Serialization
         /// <returns>A DateTime object for the given time.</returns>
         public static DateTime ConvertFromEpochTime(long epochTime)
         {
-            long totalTicks = (epochMilliseconds + epochTime) * TimeSpan.TicksPerMillisecond;
+            long totalTicks = (EpochMilliseconds + epochTime) * TimeSpan.TicksPerMillisecond;
 
             return new DateTime(totalTicks, DateTimeKind.Utc);
         }
@@ -54,7 +54,7 @@ namespace Contrast.Serialization
         /// <returns>A milliseconds representation of Unix time.</returns>
         public static long ConvertToEpochTime(DateTime dateTime)
         {
-            double mSecs = (dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond) - epochMilliseconds;
+            double mSecs = (dateTime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond) - EpochMilliseconds;
             long result;
 
             try

--- a/tests/ContrastRestClient.Tests/TeamServerClientOrganizationTest.cs
+++ b/tests/ContrastRestClient.Tests/TeamServerClientOrganizationTest.cs
@@ -73,7 +73,7 @@ namespace ContrastRestClient.Tests
             var response = teamServerClient.GetOrganizationInfo("orgId");
 
             Assert.IsTrue(response.Success);
-            Assert.AreEqual(response.Organization.name, "Test organization");
+            Assert.AreEqual(response.Organization.Name, "Test organization");
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace ContrastRestClient.Tests
             var response = teamServerClient.GetOrganizationInfo("orgId", new List<OrganizationExpandValues>{ OrganizationExpandValues.freemium });
 
             Assert.IsTrue(response.Success);
-            Assert.AreEqual(response.Organization.name, "Test organization");
+            Assert.AreEqual(response.Organization.Name, "Test organization");
         }
     }
 }

--- a/tests/ContrastRestClient.Tests/TeamServerClientTest.cs
+++ b/tests/ContrastRestClient.Tests/TeamServerClientTest.cs
@@ -129,7 +129,7 @@ namespace ContrastRestClient.Tests
 
             Assert.AreEqual(1, apps.Count);
             ContrastApplication app = apps[0];
-            Assert.AreEqual("2b75b619-8a37-463e-b605-bd8f340d03aa", app.AppID);
+            Assert.AreEqual("2b75b619-8a37-463e-b605-bd8f340d03aa", app.AppId);
             Assert.AreEqual("MyTestApp", app.Name);
         }
 
@@ -341,7 +341,7 @@ namespace ContrastRestClient.Tests
 
             Assert.AreEqual(1, traces.Count);
             Trace trace = traces[0];
-            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Uuid);
+            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Id);
             Assert.AreEqual(14, trace.Request.Headers.Count);
             Assert.AreEqual(4, trace.Request.Parameters.Count);
         }
@@ -431,7 +431,7 @@ namespace ContrastRestClient.Tests
 
             Assert.AreEqual(1, traces.Count);
             Trace trace = traces[0];
-            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Uuid);
+            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Id);
             Assert.AreEqual("SQL Injection from \"account_name\" Parameter on \"attack\" page", trace.Title);
             Assert.IsNull(trace.Request);
             Assert.AreEqual(expectedDate, trace.FirstTimeSeen);
@@ -500,7 +500,7 @@ namespace ContrastRestClient.Tests
 
             Assert.AreEqual(1, traces.Count);
             Trace trace = traces[0];
-            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Uuid);
+            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Id);
             Assert.AreEqual("Critical", trace.Severity);
             Assert.AreEqual("sql-injection", trace.RuleName);
         }
@@ -568,7 +568,7 @@ namespace ContrastRestClient.Tests
 
             Assert.AreEqual(1, traces.Count);
             Trace trace = traces[0];
-            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Uuid);
+            Assert.AreEqual("4AD2-6HT1-X845-IVXE", trace.Id);
             Assert.AreEqual("CRITICAL", trace.DefaultSeverity);
             Assert.IsFalse(trace.HasParentApp);
         }
@@ -1055,7 +1055,7 @@ namespace ContrastRestClient.Tests
                 new MemoryStream(Encoding.UTF8.GetBytes(storyJson))
                 );
             var teamServerClient = new Client(mockSdkHttpClient.Object);
-            var filterResponse = teamServerClient.GetApplicationTraceFilterSubfilters("orgId", "appId", TraceFilterType.servers, null);
+            var filterResponse = teamServerClient.GetApplicationTraceFilterSubFilters("orgId", "appId", TraceFilterType.servers, null);
 
             Assert.AreEqual(2, filterResponse.Filters.Count);
             var filter = filterResponse.Filters[1];
@@ -1106,7 +1106,7 @@ namespace ContrastRestClient.Tests
                 new MemoryStream(Encoding.UTF8.GetBytes(storyJson))
                 );
             var teamServerClient = new Client(mockSdkHttpClient.Object);
-            var filterResponse = teamServerClient.GetServerTraceFilterSubfilters("orgId", 1111, TraceFilterType.modules, null);
+            var filterResponse = teamServerClient.GetServerTraceFilterSubFilters("orgId", 1111, TraceFilterType.modules, null);
 
             Assert.AreEqual(1, filterResponse.Filters.Count);
             var filter = filterResponse.Filters[0];


### PR DESCRIPTION
- (.Net Convention) Use correct naming conventions (PascalCase for public members, no SCREAMING_CASE, no Snake_Case).
- (.Net Convention) Vulns -> Vulnerabilities (perfer full spelling of all works on public members)
- Some `Uuid` were named `Id`, normalized all `Uuid` to favor `Id`
- Fixed the spelling of some public members.

```
IContrastRestClient.PostApplicatonSpecificMessage > IContrastRestClient.PostApplicationSpecificMessage
ContrastApplication.Stauts -> ContrastApplication.Status
```

There are two property mappings that may be incorrect:

```
    [JsonObject]
    public class TraceEventDetailResponse
    {
        [JsonProperty(PropertyName = "succes")]
        public bool Success { get; set; }
    }


    public class Server
    {
        [JsonProperty(PropertyName = "assess_sensonrs")]
        public bool AssessSensors { get; set; }
    }
```

The naming of the projects/root namespace does not follow .Net/NuGet conventions. The NuGet package is called ContrastRestClient, which should match the assembly name, which should match the root namespace (but is Contrast).

Additionally, the type `ContrastRestClient` does not follow .Net naming conventions, as the name should not match the assembly name (requires full-qualification). One of these should be renamed.


TODO
- [ ] `ContrastRestClient` type/assembly
- [ ] Enums do not match naming conventions (PascalCase)
- [ ] Possibly invalid json mappings.
- [ ] Namespaces are not conventional (should match root namespace).