### PR TITLE
 Implement GET api/ng/{orgUuid}/modules/{appId}, GET api/ng/{orgUuid}/applications/{appId}/servers

### DIFF
--- a/src/ContrastRestClient/Client.cs
+++ b/src/ContrastRestClient/Client.cs
@@ -214,6 +214,42 @@ namespace Contrast
             string endpoint = String.Format(NgEndpoints.APPLICATIONS, organizationId, String.Empty);
             return (GetResponseAndDeserialize<ApplicationsResponse>(endpoint));
         }
+        
+        /// <summary>
+        /// Get the summary information about the modules in a single merged application.
+        /// </summary>
+        /// <param name="organizationId">the uuid of the user's organization</param>
+        /// <param name="appId">the ID of the application</param>
+        /// <returns>A response object which contains a list of ModuleResources, each with a ContrastApplication object
+        /// designated as the Master, and a List of ContrastApplication objects designated as the Modules. The Master is 
+        /// not included in the Modules list. </returns>
+        /// <exception cref=" cref="System.AggregateException">Thrown when there is an error communicating with TeamServer</exception>
+        public ModulesResponse GetModule(string organizationId, string appId)
+        {
+            string endpoint = string.Format(NgEndpoints.MODULES, organizationId, appId);
+            return GetResponseAndDeserialize<ModulesResponse>(endpoint);
+        }
+
+        /// <summary>
+        /// Get the list of modules in each of the merged applications monitored by Contrast.
+        /// </summary>
+        /// <param name="organizationId">the uuid of the user's organization</param>
+        /// <returns>A response object which contains a list of ModuleResources, each with a ContrastApplication object
+        /// designated as the Master, and a List of ContrastApplication objects designated as the Modules. The Master is 
+        /// not included in the Modules list. </returns>
+        /// <exception cref=" cref="System.AggregateException">Thrown when there is an error communicating with TeamServer</exception>
+        public ModulesResponse GetModules(string organizationId)
+        {
+            string endpoint = string.Format(NgEndpoints.MODULES, organizationId, string.Empty);
+            return GetResponseAndDeserialize<ModulesResponse>(endpoint);
+        }
+
+        /// <returns></returns>
+        public ServersResponse GetApplicationServers(string organizationId, string appId)
+        {
+            string endpoint = String.Format(NgEndpoints.APPLICATION_SERVERS, organizationId, appId);
+            return (GetResponseAndDeserialize<ServersResponse>(endpoint));
+        }
 
         /// <summary>
         /// Resets an application's library, coverage, statistics and trace information.

--- a/src/ContrastRestClient/Client.cs
+++ b/src/ContrastRestClient/Client.cs
@@ -214,20 +214,21 @@ namespace Contrast
             string endpoint = String.Format(NgEndpoints.APPLICATIONS, organizationId, String.Empty);
             return (GetResponseAndDeserialize<ApplicationsResponse>(endpoint));
         }
-        
+
         /// <summary>
-        /// Get the summary information about the modules in a single merged application.
+        /// Get information about a merged application, including its merged modules. The master is not included as
+        /// a merged module.
         /// </summary>
         /// <param name="organizationId">the uuid of the user's organization</param>
-        /// <param name="appId">the ID of the application</param>
-        /// <returns>A response object which contains a list of ModuleResources, each with a ContrastApplication object
-        /// designated as the Master, and a List of ContrastApplication objects designated as the Modules. The Master is 
-        /// not included in the Modules list. </returns>
+        /// <param name="appId">the ID of the merged application</param>
+        /// <returns>A ApplicationsResponse object which should contain a single ApplicationResource object. The
+        /// applications property contains a list of ApplicationModuleResource objects representing the modules that
+        /// have the specified appId as the master. The master app is not included in this list.</returns>
         /// <exception cref=" cref="System.AggregateException">Thrown when there is an error communicating with TeamServer</exception>
-        public ModulesResponse GetModule(string organizationId, string appId)
+        public ApplicationsResponse GetChildModules(string organizationId, string appId)
         {
             string endpoint = string.Format(NgEndpoints.MODULES, organizationId, appId);
-            return GetResponseAndDeserialize<ModulesResponse>(endpoint);
+            return GetResponseAndDeserialize<ApplicationsResponse>(endpoint);
         }
 
         /// <summary>
@@ -244,7 +245,13 @@ namespace Contrast
             return GetResponseAndDeserialize<ModulesResponse>(endpoint);
         }
 
-        /// <returns></returns>
+        /// <summary>
+        /// Get the list of servers associated with an application.
+        /// </summary>
+        /// <param name="organizationId">the uuid of the user's organization</param>
+        /// <param name="appId">the ID of the application of interest</param>
+        /// <returns>A ServersResponse object that contains a list of Server objects indicating
+        /// which servers are monitoring this application.</returns>
         public ServersResponse GetApplicationServers(string organizationId, string appId)
         {
             string endpoint = String.Format(NgEndpoints.APPLICATION_SERVERS, organizationId, appId);

--- a/src/ContrastRestClient/Model/ContrastApplication.cs
+++ b/src/ContrastRestClient/Model/ContrastApplication.cs
@@ -35,6 +35,38 @@ using Newtonsoft.Json.Converters;
 
 namespace Contrast.Model
 {
+
+    /// <summary>
+    /// A master Application and its associated merged modules.
+    /// </summary>
+    [JsonObject]
+    public class ModuleResource
+    {
+        /// <summary>
+        /// The module designated as the master application.
+        /// </summary>
+        [JsonProperty(PropertyName="master")]
+        public ContrastApplication Master { get; set; }
+
+        /// <summary>
+        /// Other application modules that are merged under the master application.
+        /// </summary>
+        [JsonProperty(PropertyName ="modules")]
+        public List<ContrastApplication> Modules { get; set; }
+    }
+
+    [JsonObject]
+    public class ModulesResponse
+    {
+        [JsonProperty(PropertyName ="applications")]
+        public List<ModuleResource> Applications { get; set; }
+        [JsonProperty(PropertyName = "messages")]
+        public List<string> Messages { get; set; }
+        [JsonProperty(PropertyName = "success")]
+        public bool Success { get; set; }
+    }
+
+
     /// <summary>
     /// An application that is being monitored by Contrast.
     /// </summary>

--- a/src/ContrastRestClient/NgEndpoints.cs
+++ b/src/ContrastRestClient/NgEndpoints.cs
@@ -33,6 +33,7 @@ namespace Contrast
     {
         internal static string APPLICATIONS = "api/ng/{0}/applications/{1}";
         internal static string APPLICATION_LIBRARIES = "api/ng/{0}/applications/{1}/libraries";
+        internal static string APPLICATION_SERVERS = "api/ng/{0}/applications/{1}/servers";
         internal static string APPLICATION_TRACES = "api/ng/{0}/traces/{1}/filter";
         internal static string APPLICATION_TRACE_TAGS = "api/ng/{0}/tags/traces/application/{1}";
         internal static string APPLICATION_TRACE_MARK_STATUS = "api/ng/{0}/traces/{1}/mark";
@@ -65,5 +66,6 @@ namespace Contrast
         internal static string TRACES_TAGS = "api/ng/{0}/tags/traces";
         internal static string TRACES_TAG_BULK = "api/ng/{0}/tags/traces/bulk";
         internal static string TRACE_MARK_STATUS = "api/ng/{0}/orgtraces/mark";
+        internal static string MODULES = "api/ng/{0}/modules/{1}";
     }
 }


### PR DESCRIPTION
This implements .../applications/{appId}/servers, useful for finding which servers are hosting an application; and .../modules, useful for seeing what application modules have been grouped together with a master application.