### PR TITLE
TS-19102 Fix Tracked and Untracked Filters on Contrast SDK .NET Library

### DIFF
--- a/src/ContrastRestClient/ContrastRestClient.csproj
+++ b/src/ContrastRestClient/ContrastRestClient.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="../../$(PackageLicenseFile)" Pack="true" PackagePath="$(PackageLicenseFile)" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/src/ContrastRestClient/Http/TraceFilter.cs
+++ b/src/ContrastRestClient/Http/TraceFilter.cs
@@ -47,6 +47,8 @@ namespace Contrast.Http
         public List<string> VulnTypes { get; set; }
         public List<string> AppVersionTags { get; set; }
         public List<long> ServerIds { get; set; }
+        public Boolean BeingTracket { get; set; }
+        public Boolean Untracked { get; set; }
         /// <summary>
         /// Server environments.
         /// </summary>
@@ -89,6 +91,8 @@ namespace Contrast.Http
             Limit = -1;
             Offset = -1;
             Sort = "";
+            BeingTracket = false;
+            Untracked = false;
         }
 
         public override string ToString()
@@ -142,6 +146,9 @@ namespace Contrast.Http
 
             if (Offset > -1)
                 filters.Add("offset=" + Offset);
+
+            filters.Add("tracked=" + BeingTracket);
+            filters.Add("untracked=" + Untracked);
 
             if (filters.Count > 0)
                 return "?" + String.Join("&", filters);

--- a/src/ContrastRestClient/Http/TraceFilter.cs
+++ b/src/ContrastRestClient/Http/TraceFilter.cs
@@ -47,7 +47,7 @@ namespace Contrast.Http
         public List<string> VulnTypes { get; set; }
         public List<string> AppVersionTags { get; set; }
         public List<long> ServerIds { get; set; }
-        public Boolean BeingTracket { get; set; }
+        public Boolean BeingTracked { get; set; }
         public Boolean Untracked { get; set; }
         /// <summary>
         /// Server environments.
@@ -91,7 +91,7 @@ namespace Contrast.Http
             Limit = -1;
             Offset = -1;
             Sort = "";
-            BeingTracket = false;
+            BeingTracked = false;
             Untracked = false;
         }
 
@@ -147,7 +147,7 @@ namespace Contrast.Http
             if (Offset > -1)
                 filters.Add("offset=" + Offset);
 
-            filters.Add("tracked=" + BeingTracket);
+            filters.Add("tracked=" + BeingTracked);
             filters.Add("untracked=" + Untracked);
 
             if (filters.Count > 0)

--- a/tests/ContrastRestClient.Tests/ContrastRestClient.Tests.csproj
+++ b/tests/ContrastRestClient.Tests/ContrastRestClient.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ContrastRestClient\ContrastRestClient.csproj" />

--- a/tests/ContrastRestClient.Tests/FilterTest.cs
+++ b/tests/ContrastRestClient.Tests/FilterTest.cs
@@ -28,6 +28,7 @@
 #endregion
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Contrast.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -54,6 +55,8 @@ namespace ContrastRestClient.Tests
             Assert.IsTrue(query.Contains("limit"));
             Assert.IsTrue(query.Contains("expand=applications"));
             Assert.IsTrue(query.Contains("status=Denied"));
+            Assert.IsTrue(query.Contains("tracked=false"));
+            Assert.IsTrue(query.Contains("untracked=false"));
             Assert.IsTrue(query.Contains("q=any"));
             Assert.IsFalse(query.Contains("applicationIds"));
             Assert.IsFalse(query.Contains("logLevels"));
@@ -71,6 +74,8 @@ namespace ContrastRestClient.Tests
             filter.Sort = "any";
             filter.Expand = new List<TraceExpandValue>();
             filter.Expand.Add(TraceExpandValue.application);
+            filter.Untracked = true;
+            filter.BeingTracket = true;
 
             string qs = filter.ToString();
 
@@ -79,6 +84,8 @@ namespace ContrastRestClient.Tests
             Assert.IsTrue(qs.Contains("urls=http://dummytest"));
             Assert.IsTrue(qs.Contains("sort=any"));
             Assert.IsTrue(qs.Contains("expand=application"));
+            Assert.IsTrue(qs.Contains("tracked=true"));
+            Assert.IsTrue(qs.Contains("untracked=true"));
 
             Assert.IsFalse(qs.Contains("limit"));
             Assert.IsFalse(qs.Contains("endDate"));

--- a/tests/ContrastRestClient.Tests/FilterTest.cs
+++ b/tests/ContrastRestClient.Tests/FilterTest.cs
@@ -55,8 +55,6 @@ namespace ContrastRestClient.Tests
             Assert.IsTrue(query.Contains("limit"));
             Assert.IsTrue(query.Contains("expand=applications"));
             Assert.IsTrue(query.Contains("status=Denied"));
-            Assert.IsTrue(query.Contains("tracked=false"));
-            Assert.IsTrue(query.Contains("untracked=false"));
             Assert.IsTrue(query.Contains("q=any"));
             Assert.IsFalse(query.Contains("applicationIds"));
             Assert.IsFalse(query.Contains("logLevels"));

--- a/tests/ContrastRestClient.Tests/FilterTest.cs
+++ b/tests/ContrastRestClient.Tests/FilterTest.cs
@@ -73,7 +73,7 @@ namespace ContrastRestClient.Tests
             filter.Expand = new List<TraceExpandValue>();
             filter.Expand.Add(TraceExpandValue.application);
             filter.Untracked = true;
-            filter.BeingTracket = true;
+            filter.BeingTracked = true;
 
             string qs = filter.ToString();
 
@@ -82,8 +82,8 @@ namespace ContrastRestClient.Tests
             Assert.IsTrue(qs.Contains("urls=http://dummytest"));
             Assert.IsTrue(qs.Contains("sort=any"));
             Assert.IsTrue(qs.Contains("expand=application"));
-            Assert.IsTrue(qs.Contains("tracked=true"));
-            Assert.IsTrue(qs.Contains("untracked=true"));
+            Assert.IsTrue(qs.Contains("tracked=True"));
+            Assert.IsTrue(qs.Contains("untracked=True"));
 
             Assert.IsFalse(qs.Contains("limit"));
             Assert.IsFalse(qs.Contains("endDate"));


### PR DESCRIPTION
The SDK was updated to have beingTracked and Untracked flags filters separated from the Status Filter